### PR TITLE
feat: relax commit bounds

### DIFF
--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -94,18 +94,17 @@ where P: Compressable + MultiscalarMul<Point = P> + Clone
 {
     /// Creates a Pedersen commitment using the value scalar and a blinding factor vector
     pub fn commit(&self, value: Scalar, blindings: &[Scalar]) -> Result<P, ProofError> {
-        let extension_degree = self.extension_degree as usize;
-        if blindings.is_empty() || blindings.len() != extension_degree {
+        if blindings.is_empty() || blindings.len() > self.extension_degree as usize {
             Err(ProofError::InvalidLength("blinding vector".to_string()))
         } else {
-            let mut scalars = Vec::with_capacity(1 + extension_degree);
+            let mut scalars = Vec::with_capacity(1 + blindings.len());
             scalars.push(value);
             for item in blindings {
                 scalars.push(*item);
             }
-            let mut points = Vec::with_capacity(1 + extension_degree);
+            let mut points = Vec::with_capacity(1 + blindings.len());
             points.push(self.h_base.clone());
-            for item in self.g_base_vec.iter().take(extension_degree) {
+            for item in self.g_base_vec.iter().take(blindings.len()) {
                 points.push(item.clone());
             }
             Ok(P::multiscalar_mul(&scalars, &points))

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -181,6 +181,15 @@ mod tests {
     use super::*;
     use crate::protocols::scalar_protocol::ScalarProtocol;
 
+    static EXTENSION_DEGREE: [ExtensionDegree; 6] = [
+        ExtensionDegree::Zero,
+        ExtensionDegree::One,
+        ExtensionDegree::Two,
+        ExtensionDegree::Three,
+        ExtensionDegree::Four,
+        ExtensionDegree::Five,
+    ];
+
     #[test]
     fn test_constants() {
         // Extended Pedersen generators with extension degree of zero to five
@@ -192,14 +201,7 @@ mod tests {
             *RISTRETTO_BASEPOINT_POINT_BLINDING_5,
             *RISTRETTO_BASEPOINT_POINT_BLINDING_6,
         ];
-        for extension_degree in [
-            ExtensionDegree::Zero,
-            ExtensionDegree::One,
-            ExtensionDegree::Two,
-            ExtensionDegree::Three,
-            ExtensionDegree::Four,
-            ExtensionDegree::Five,
-        ] {
+        for extension_degree in EXTENSION_DEGREE {
             let pc_gens = create_pedersen_gens_with_extension_degree(extension_degree);
             for (i, item) in lazy_statics.iter().enumerate().take(pc_gens.extension_degree as usize) {
                 assert_eq!(pc_gens.g_base_vec[i].compress(), pc_gens.g_base_compressed_vec[i]);
@@ -223,17 +225,12 @@ mod tests {
             Scalar::random_not_zero(&mut rng),
         ];
 
-        for extension_degree in [
-            ExtensionDegree::Zero,
-            ExtensionDegree::One,
-            ExtensionDegree::Two,
-            ExtensionDegree::Three,
-            ExtensionDegree::Four,
-            ExtensionDegree::Five,
-        ] {
+        for extension_degree in EXTENSION_DEGREE {
             let pc_gens = create_pedersen_gens_with_extension_degree(extension_degree);
             for i in 0..ExtensionDegree::Five as usize {
-                if i == extension_degree as usize {
+                // All commitments where enough extended generators are available to enable multi-exponentiation
+                // multiplication of the blinding factor vector will be ok
+                if i > 0 && i <= extension_degree as usize {
                     assert!(pc_gens.commit(value, blindings[..i].to_owned().as_slice()).is_ok());
                 } else {
                     assert!(pc_gens.commit(value, blindings[..i].to_owned().as_slice()).is_err());


### PR DESCRIPTION
Relaxed commit bounds by allowing generators with more extension degrees (that remain unused) as is strictly necessary for the resulting multi-exponentiation multiplication.