### PR TITLE
chore: reword extension degree enums

### DIFF
--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -18,7 +18,7 @@ use tari_bulletproofs_plus::{
 };
 
 // Reduced spectrum of tests for the sake of CI bench tests
-static EXTENSION_DEGREE: [ExtensionDegree; 2] = [ExtensionDegree::Zero, ExtensionDegree::Five];
+static EXTENSION_DEGREE: [ExtensionDegree; 2] = [ExtensionDegree::DefaultPedersen, ExtensionDegree::AddFiveBasePoints];
 static BP_GENS_ARR: [usize; 5] = [0, 3, 5, 7, 9];
 // To do a full spectrum of tests, use these constants instead
 // static EXTENSION_DEGREE: [ExtensionDegree; 6] = [

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -30,7 +30,7 @@ use tari_bulletproofs_plus::{
 static AGGREGATION_SIZES: [usize; 4] = [1, 2, 4, 8];
 static BATCHED_SIZES: [usize; 4] = [1, 2, 4, 8];
 static BIT_LENGTHS: [usize; 3] = [2, 4, 8];
-static EXTENSION_DEGREE: [ExtensionDegree; 1] = [ExtensionDegree::Zero];
+static EXTENSION_DEGREE: [ExtensionDegree; 1] = [ExtensionDegree::DefaultPedersen];
 static EXTRACT_MASKS: [VerifyAction; 1] = [VerifyAction::VerifyOnly];
 // To do a full spectrum of tests, use these constants instead
 // static AGGREGATION_SIZES: [usize; 6] = [1, 2, 4, 8, 16, 32];
@@ -101,7 +101,7 @@ fn create_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
 
 fn create_aggregated_rangeproof_n_small(c: &mut Criterion) {
     for bit_length in BIT_LENGTHS {
-        create_aggregated_rangeproof_helper(bit_length, ExtensionDegree::Zero, c);
+        create_aggregated_rangeproof_helper(bit_length, ExtensionDegree::DefaultPedersen, c);
     }
 }
 
@@ -178,7 +178,7 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
 
 fn verify_aggregated_rangeproof_n_small(c: &mut Criterion) {
     for bit_length in BIT_LENGTHS {
-        verify_aggregated_rangeproof_helper(bit_length, ExtensionDegree::Zero, c);
+        verify_aggregated_rangeproof_helper(bit_length, ExtensionDegree::DefaultPedersen, c);
     }
 }
 

--- a/src/extended_mask.rs
+++ b/src/extended_mask.rs
@@ -10,18 +10,29 @@ use crate::{errors::ProofError, generators::pedersen_gens::ExtensionDegree};
 /// Contains the embedded extended mask for non-aggregated proofs
 #[derive(Debug, PartialEq)]
 pub struct ExtendedMask {
-    extended_mask: Vec<Scalar>, // Do not allow direct assignment of struct member (i.e. should not be public)
+    blindings: Vec<Scalar>, // Do not allow direct assignment of struct member (i.e. should not be public)
 }
 
 impl ExtendedMask {
     /// Construct a new extended mask
-    pub fn assign(extension_degree: ExtensionDegree, extended_mask: Vec<Scalar>) -> Result<ExtendedMask, ProofError> {
-        if extended_mask.is_empty() || extended_mask.len() != extension_degree as usize {
+    pub fn assign(extension_degree: ExtensionDegree, blindings: Vec<Scalar>) -> Result<ExtendedMask, ProofError> {
+        if blindings.is_empty() || blindings.len() != extension_degree as usize {
             Err(ProofError::InvalidLength(
                 "Extended mask length must correspond to the extension degree".to_string(),
             ))
         } else {
-            Ok(Self { extended_mask })
+            Ok(Self { blindings })
+        }
+    }
+
+    /// Return the extended mask blinding factors
+    pub fn blindings(&self) -> Result<Vec<Scalar>, ProofError> {
+        if self.blindings.is_empty() {
+            Err(ProofError::InvalidLength(
+                "Extended mask values not assigned yet".to_string(),
+            ))
+        } else {
+            Ok(self.blindings.clone())
         }
     }
 }

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -39,29 +39,29 @@ pub struct PedersenGens<P: Compressable> {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ExtensionDegree {
     /// Default Pedersen commitment
-    Zero = 1,
+    DefaultPedersen = 1,
     /// Pedersen commitment extended with one degree
-    One = 2,
+    AddOneBasePoint = 2,
     /// Pedersen commitment extended with two degrees
-    Two = 3,
+    AddTwoBasePoints = 3,
     /// Pedersen commitment extended with three degrees
-    Three = 4,
+    AddThreeBasePoints = 4,
     /// Pedersen commitment extended with four degrees
-    Four = 5,
+    AddFourBasePoints = 5,
     /// Pedersen commitment extended with five degrees
-    Five = 6,
+    AddFiveBasePoints = 6,
 }
 
 impl ExtensionDegree {
     /// Helper function to convert a size into an extension degree
     pub fn try_from_size(size: usize) -> Result<ExtensionDegree, ProofError> {
         match size {
-            1 => Ok(ExtensionDegree::Zero),
-            2 => Ok(ExtensionDegree::One),
-            3 => Ok(ExtensionDegree::Two),
-            4 => Ok(ExtensionDegree::Three),
-            5 => Ok(ExtensionDegree::Four),
-            6 => Ok(ExtensionDegree::Five),
+            1 => Ok(ExtensionDegree::DefaultPedersen),
+            2 => Ok(ExtensionDegree::AddOneBasePoint),
+            3 => Ok(ExtensionDegree::AddTwoBasePoints),
+            4 => Ok(ExtensionDegree::AddThreeBasePoints),
+            5 => Ok(ExtensionDegree::AddFourBasePoints),
+            6 => Ok(ExtensionDegree::AddFiveBasePoints),
             _ => Err(ProofError::InvalidArgument("Extension degree not valid".to_string())),
         }
     }

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -97,7 +97,7 @@ pub const MAX_RANGE_PROOF_BIT_LENGTH: usize = 64;
 ///
 /// for aggregation_size in proof_batch {
 ///     // 1. Generators
-///     let extension_degree = ExtensionDegree::Zero;
+///     let extension_degree = ExtensionDegree::DefaultPedersen;
 ///     let pc_gens = ristretto::create_pedersen_gens_with_extension_degree(extension_degree);
 ///     let generators = RangeParameters::init(bit_length, aggregation_size, pc_gens).unwrap();
 ///
@@ -954,7 +954,7 @@ mod tests {
             d1: vec![],
             li: vec![],
             ri: vec![],
-            extension_degree: ExtensionDegree::Zero,
+            extension_degree: ExtensionDegree::DefaultPedersen,
         };
         let proof_bytes = proof.to_bytes();
         assert!(RistrettoRangeProof::from_bytes(&proof_bytes).is_err());
@@ -968,7 +968,7 @@ mod tests {
             d1: vec![Scalar::default()],
             li: vec![CompressedRistretto::default()],
             ri: vec![CompressedRistretto::default()],
-            extension_degree: ExtensionDegree::Zero,
+            extension_degree: ExtensionDegree::DefaultPedersen,
         };
         let proof_bytes = proof.to_bytes();
         assert!(RistrettoRangeProof::from_bytes(&proof_bytes).is_ok());
@@ -989,7 +989,7 @@ mod tests {
             ],
             li: vec![CompressedRistretto::default()],
             ri: vec![CompressedRistretto::default()],
-            extension_degree: ExtensionDegree::Five,
+            extension_degree: ExtensionDegree::AddFiveBasePoints,
         };
         let proof_bytes = proof.to_bytes();
         assert!(RistrettoRangeProof::from_bytes(&proof_bytes).is_ok());

--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -34,7 +34,7 @@ impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
     pub fn init(
         generators: RangeParameters<P>,
         commitments: Vec<P>,
-        minimum_value_promise: Vec<Option<u64>>,
+        minimum_value_promises: Vec<Option<u64>>,
         seed_nonce: Option<Scalar>,
     ) -> Result<Self, ProofError> {
         if !commitments.len().is_power_of_two() {
@@ -42,7 +42,7 @@ impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
                 "Number of commitments must be a power of two".to_string(),
             ));
         }
-        if !minimum_value_promise.len() == commitments.len() {
+        if !minimum_value_promises.len() == commitments.len() {
             return Err(ProofError::InvalidArgument(
                 "Incorrect number of minimum value promises".to_string(),
             ));
@@ -65,7 +65,7 @@ impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
             generators,
             commitments,
             commitments_compressed,
-            minimum_value_promises: minimum_value_promise,
+            minimum_value_promises,
             seed_nonce,
         })
     }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -71,10 +71,10 @@ pub fn create_pedersen_gens_with_extension_degree(extension_degree: ExtensionDeg
 // on the fly compression for compressed base points otherwise
 fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<CompressedRistretto>) {
     match extension_degree {
-        ExtensionDegree::Zero => (vec![*RISTRETTO_BASEPOINT_POINT_BLINDING_1], vec![
+        ExtensionDegree::DefaultPedersen => (vec![*RISTRETTO_BASEPOINT_POINT_BLINDING_1], vec![
             *RISTRETTO_BASEPOINT_COMPRESSED_BLINDING_1,
         ]),
-        ExtensionDegree::One => (
+        ExtensionDegree::AddOneBasePoint => (
             vec![
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_1,
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_2,
@@ -84,7 +84,7 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
                 *RISTRETTO_BASEPOINT_COMPRESSED_BLINDING_2,
             ],
         ),
-        ExtensionDegree::Two => (
+        ExtensionDegree::AddTwoBasePoints => (
             vec![
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_1,
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_2,
@@ -96,7 +96,7 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
                 *RISTRETTO_BASEPOINT_COMPRESSED_BLINDING_3,
             ],
         ),
-        ExtensionDegree::Three => (
+        ExtensionDegree::AddThreeBasePoints => (
             vec![
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_1,
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_2,
@@ -110,7 +110,7 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
                 *RISTRETTO_BASEPOINT_COMPRESSED_BLINDING_4,
             ],
         ),
-        ExtensionDegree::Four => (
+        ExtensionDegree::AddFourBasePoints => (
             vec![
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_1,
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_2,
@@ -126,7 +126,7 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
                 *RISTRETTO_BASEPOINT_COMPRESSED_BLINDING_5,
             ],
         ),
-        ExtensionDegree::Five => (
+        ExtensionDegree::AddFiveBasePoints => (
             vec![
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_1,
                 *RISTRETTO_BASEPOINT_POINT_BLINDING_2,
@@ -182,12 +182,12 @@ mod tests {
     use crate::protocols::scalar_protocol::ScalarProtocol;
 
     static EXTENSION_DEGREE: [ExtensionDegree; 6] = [
-        ExtensionDegree::Zero,
-        ExtensionDegree::One,
-        ExtensionDegree::Two,
-        ExtensionDegree::Three,
-        ExtensionDegree::Four,
-        ExtensionDegree::Five,
+        ExtensionDegree::DefaultPedersen,
+        ExtensionDegree::AddOneBasePoint,
+        ExtensionDegree::AddTwoBasePoints,
+        ExtensionDegree::AddThreeBasePoints,
+        ExtensionDegree::AddFourBasePoints,
+        ExtensionDegree::AddFiveBasePoints,
     ];
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
 
         for extension_degree in EXTENSION_DEGREE {
             let pc_gens = create_pedersen_gens_with_extension_degree(extension_degree);
-            for i in 0..ExtensionDegree::Five as usize {
+            for i in 0..ExtensionDegree::AddFiveBasePoints as usize {
                 // All commitments where enough extended generators are available to enable multi-exponentiation
                 // multiplication of the blinding factor vector will be ok
                 if i > 0 && i <= extension_degree as usize {

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -26,25 +26,25 @@ fn test_non_aggregated_single_proof_multiple_bit_lengths() {
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::NoOffset,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::One,
+        ExtensionDegree::AddOneBasePoint,
         &ProofOfMinimumValueStrategy::Intermediate,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Two,
+        ExtensionDegree::AddTwoBasePoints,
         &ProofOfMinimumValueStrategy::EqualToValue,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::LargerThanValue,
     );
 }
@@ -56,25 +56,25 @@ fn test_aggregated_single_proof_multiple_bit_lengths() {
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::NoOffset,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::One,
+        ExtensionDegree::AddOneBasePoint,
         &ProofOfMinimumValueStrategy::Intermediate,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Two,
+        ExtensionDegree::AddTwoBasePoints,
         &ProofOfMinimumValueStrategy::EqualToValue,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::LargerThanValue,
     );
 }
@@ -86,25 +86,25 @@ fn test_non_aggregated_multiple_proofs_single_bit_length() {
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::NoOffset,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::One,
+        ExtensionDegree::AddOneBasePoint,
         &ProofOfMinimumValueStrategy::Intermediate,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Two,
+        ExtensionDegree::AddTwoBasePoints,
         &ProofOfMinimumValueStrategy::EqualToValue,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::LargerThanValue,
     );
 }
@@ -116,25 +116,25 @@ fn test_mixed_aggregation_multiple_proofs_single_bit_length() {
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::NoOffset,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::One,
+        ExtensionDegree::AddOneBasePoint,
         &ProofOfMinimumValueStrategy::Intermediate,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Two,
+        ExtensionDegree::AddTwoBasePoints,
         &ProofOfMinimumValueStrategy::EqualToValue,
     );
     prove_and_verify(
         &bit_lengths,
         &proof_batch,
-        ExtensionDegree::Zero,
+        ExtensionDegree::DefaultPedersen,
         &ProofOfMinimumValueStrategy::LargerThanValue,
     );
 }
@@ -193,10 +193,6 @@ fn prove_and_verify(
                 openings.push(CommitmentOpening::new(value, blindings.clone()));
                 if m == 0 {
                     if *aggregation_size == 1 {
-                        // let mut temp_masks: Vec<Scalar> = Vec::with_capacity(extension_degree as usize);
-                        // for item in blindings {
-                        //     temp_masks.push(item);
-                        // }
                         private_masks.push(Some(ExtendedMask::assign(extension_degree, blindings).unwrap()));
                         public_masks.push(None);
                     } else {


### PR DESCRIPTION
Reword extension degree enums to better describe the extension degree and to not use an 'off by one' type logic