### PR TITLE
feat: add methods to retrieve extension degree

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -33,7 +33,7 @@ use crate::{
     range_witness::RangeWitness,
     traits::{Compressable, Decompressable, FixedBytesRepr},
     transcripts,
-    utils::generic::{bit_vector_of_scalars, nonce, read32, read8},
+    utils::generic::{bit_vector_of_scalars, nonce, read_1_byte, read_32_bytes},
 };
 
 /// Optionally extract masks when verifying the proofs
@@ -842,7 +842,7 @@ where
                 "Invalid serialized proof bytes length".to_string(),
             ));
         }
-        let extension_degree = ExtensionDegree::try_from(read8(&slice[0..])[0] as usize)?;
+        let extension_degree = ExtensionDegree::try_from(read_1_byte(&slice[0..])[0] as usize)?;
         let num_elements = (slice.len() - 1) / 32;
         if num_elements < 2 + 5 + extension_degree as usize {
             return Err(ProofError::InvalidLength(
@@ -860,24 +860,24 @@ where
         let mut li = Vec::with_capacity(n);
         let mut ri = Vec::with_capacity(n);
         for i in 0..n {
-            li.push(P::Compressed::from_fixed_bytes(read32(&slice[1 + i * 32..])));
+            li.push(P::Compressed::from_fixed_bytes(read_32_bytes(&slice[1 + i * 32..])));
         }
         for i in n..2 * n {
-            ri.push(P::Compressed::from_fixed_bytes(read32(&slice[1 + i * 32..])));
+            ri.push(P::Compressed::from_fixed_bytes(read_32_bytes(&slice[1 + i * 32..])));
         }
 
         let pos = 1 + 2 * n * 32;
-        let a = P::Compressed::from_fixed_bytes(read32(&slice[pos..]));
-        let a1 = P::Compressed::from_fixed_bytes(read32(&slice[pos + 32..]));
-        let b = P::Compressed::from_fixed_bytes(read32(&slice[pos + 64..]));
-        let r1 = Scalar::from_canonical_bytes(read32(&slice[pos + 96..]))
+        let a = P::Compressed::from_fixed_bytes(read_32_bytes(&slice[pos..]));
+        let a1 = P::Compressed::from_fixed_bytes(read_32_bytes(&slice[pos + 32..]));
+        let b = P::Compressed::from_fixed_bytes(read_32_bytes(&slice[pos + 64..]));
+        let r1 = Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 96..]))
             .ok_or_else(|| ProofError::InvalidArgument("r1 bytes not a canonical byte representation".to_string()))?;
-        let s1 = Scalar::from_canonical_bytes(read32(&slice[pos + 128..]))
+        let s1 = Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 128..]))
             .ok_or_else(|| ProofError::InvalidArgument("s1 bytes not a canonical byte representation".to_string()))?;
         let mut d1 = Vec::with_capacity(extension_degree as usize);
         for i in 0..extension_degree as usize {
             d1.push(
-                Scalar::from_canonical_bytes(read32(&slice[pos + 160 + i * 32..])).ok_or_else(|| {
+                Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 160 + i * 32..])).ok_or_else(|| {
                     ProofError::InvalidArgument("d1 bytes not a canonical byte representation".to_string())
                 })?,
             );
@@ -903,7 +903,7 @@ where
                 "Invalid serialized proof bytes length".to_string(),
             ));
         }
-        ExtensionDegree::try_from(read8(&slice[0..])[0] as usize)
+        ExtensionDegree::try_from(read_1_byte(&slice[0..])[0] as usize)
     }
 }
 

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -81,14 +81,14 @@ pub fn bit_vector_of_scalars(value: u64, bit_length: usize) -> Result<Vec<Scalar
 }
 
 /// Given `data` with `len >= 32`, return the first 32 bytes.
-pub fn read32(data: &[u8]) -> [u8; 32] {
+pub fn read_32_bytes(data: &[u8]) -> [u8; 32] {
     let mut buf32 = [0u8; 32];
     buf32[..].copy_from_slice(&data[..32]);
     buf32
 }
 
 /// Given `data` with `len >= 1`, return the first 1 byte.
-pub fn read8(data: &[u8]) -> [u8; 1] {
+pub fn read_1_byte(data: &[u8]) -> [u8; 1] {
     let mut buf8 = [0u8; 1];
     buf8[..].copy_from_slice(&data[..1]);
     buf8


### PR DESCRIPTION
Add methods to retrieve extension degree from a proof and a serialized proof. This will assist verifiers in ensuring that the statement contains Pedersen generators of the correct extension degree before attempting verification.