### PR TITLE
chore: revert 'curve25519-dalek'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = "0.9.1"
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["serde", "alloc"] }
 derive_more = "0.99.17"
 derivative = "2.2.0"
 digest = { version = "0.9.0", default-features = false }
@@ -19,7 +19,7 @@ rand = "0.8"
 serde = "1.0.89"
 sha3 = { version = "0.9.1", default-features = false }
 thiserror = { version = "1" }
-zeroize = "1.0.0"
+zeroize = "1.4"
 
 [dev-dependencies]
 bincode = "1"

--- a/src/protocols/curve_point_protocol.rs
+++ b/src/protocols/curve_point_protocol.rs
@@ -5,6 +5,7 @@
 
 use std::{
     borrow::Borrow,
+    cmp::min,
     ops::{Add, AddAssign, Mul},
 };
 
@@ -43,7 +44,13 @@ pub trait CurvePointProtocol:
     /// Generates an instance from the byte result of the SHA3_512 hasher.
     fn from_hash_sha3_512(hasher: Sha3_512) -> Self {
         let output = hasher.finalize();
-        Self::from_uniform_bytes(&output.into())
+        // If we use 'curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2"', change to
+        // 'Self::from_uniform_bytes(&output.into())'
+        // instead of below
+        let mut buffer = [0u8; 64];
+        let size = min(output.len(), 64);
+        (&mut buffer[0..size]).copy_from_slice(&output.as_slice()[0..size]);
+        Self::from_uniform_bytes(&buffer)
     }
 
     /// Helper function to multiply a point vector with a scalar vector


### PR DESCRIPTION
Using `curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1"`
instead of `curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2"`
due to issues with `zeroize`