### PR TITLE
feat: port to dalek for curve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_bulletproofs_plus"
-version = "0.0.6"
+version = "0.1.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -9,17 +9,18 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = "0.9.1"
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["serde", "alloc"] }
+curve25519-dalek = { package = "curve25519-dalek", version = "3.2.1", default-features = false, features = ["serde", "alloc"] }
 derive_more = "0.99.17"
 derivative = "2.2.0"
 digest = { version = "0.9.0", default-features = false }
 lazy_static = "1.4.0"
 merlin = { version = "3", default-features = false }
-rand = "0.8"
+rand = "0.7"
 serde = "1.0.89"
 sha3 = { version = "0.9.1", default-features = false }
 thiserror = { version = "1" }
-zeroize = "1.4"
+zeroize = "1.3.0"
+rand_core = { version = "0.5", default-features = false }
 
 [dev-dependencies]
 bincode = "1"

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -67,7 +67,7 @@ fn create_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             let mut openings = vec![];
             let mut rng = rand::thread_rng();
             for _ in 0..aggregation_factor {
-                let value = rng.gen_range(value_min..value_max);
+                let value = rng.gen_range(value_min, value_max);
                 minimum_values.push(Some(value / 3));
                 let blindings = vec![Scalar::random_not_zero(&mut rng); extension_degree as usize];
                 commitments.push(
@@ -139,7 +139,7 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             let mut openings = vec![];
             let mut rng = rand::thread_rng();
             for _ in 0..aggregation_factor {
-                let value = rng.gen_range(value_min..value_max);
+                let value = rng.gen_range(value_min, value_max);
                 minimum_values.push(Some(value / 3));
                 let blindings = vec![Scalar::random_not_zero(&mut rng); extension_degree as usize];
                 commitments.push(
@@ -212,7 +212,7 @@ fn verify_batched_rangeproofs_helper(bit_length: usize, extension_degree: Extens
     for _ in 0..max_range_proofs {
         // 2. Create witness data
         let mut openings = vec![];
-        let value = rng.gen_range(value_min..value_max);
+        let value = rng.gen_range(value_min, value_max);
         let blindings = vec![Scalar::random_not_zero(&mut rng); extension_degree as usize];
         openings.push(CommitmentOpening::new(value, blindings.clone()));
         let witness = RangeWitness::init(openings).unwrap();

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -175,7 +175,7 @@ fn prove_and_verify(
             let mut commitments = vec![];
             let mut minimum_values = vec![];
             for m in 0..*aggregation_size {
-                let value = rng.gen_range(value_min,value_max);
+                let value = rng.gen_range(value_min, value_max);
                 let minimum_value = match promise_strategy {
                     ProofOfMinimumValueStrategy::NoOffset => None,
                     ProofOfMinimumValueStrategy::Intermediate => Some(value / 3),

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -175,7 +175,7 @@ fn prove_and_verify(
             let mut commitments = vec![];
             let mut minimum_values = vec![];
             for m in 0..*aggregation_size {
-                let value = rng.gen_range(value_min..value_max);
+                let value = rng.gen_range(value_min,value_max);
                 let minimum_value = match promise_strategy {
                     ProofOfMinimumValueStrategy::NoOffset => None,
                     ProofOfMinimumValueStrategy::Intermediate => Some(value / 3),


### PR DESCRIPTION
Move away for `curve25519-dalek-ng` and rather use `curve25519-dalek` as this is the more updated repo.
Updated the version as this is a breaking change with respect to dependencies. 
Matched the version of `rand` to `rand_core` so that the traits can work.