### PR TITLE
feat: use precomputation on (most) fixed generators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ curve25519-dalek = { package="tari-curve25519-dalek", version = "4.0.2", default
 derive_more = "0.99.17"
 derivative = "2.2.0"
 digest = { version = "0.9.0", default-features = false }
+itertools = "0.6.0"
 lazy_static = "1.4.0"
 merlin = { version = "2", default-features = false }
 rand = "0.7"

--- a/src/generators/generators_chain.rs
+++ b/src/generators/generators_chain.rs
@@ -30,15 +30,6 @@ impl<P> GeneratorsChain<P> {
             _phantom: PhantomData,
         }
     }
-
-    /// Advances the reader n times, squeezing and discarding the result
-    pub(crate) fn fast_forward(mut self, n: usize) -> Self {
-        let mut buf = [0u8; 64];
-        for _ in 0..n {
-            self.reader.read(&mut buf);
-        }
-        self
-    }
 }
 
 impl<P> Default for GeneratorsChain<P> {

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -61,27 +61,4 @@ mod tests {
         helper(16, 2);
         helper(16, 1);
     }
-
-    #[test]
-    fn resizing_small_gens_matches_creating_bigger_gens() {
-        let gens = BulletproofGens::new(64, 8);
-
-        let mut gen_resized = BulletproofGens::new(32, 8);
-        gen_resized.increase_capacity(64);
-
-        let helper = |n: usize, m: usize| {
-            let gens_g: Vec<RistrettoPoint> = gens.g_iter(n, m).copied().collect();
-            let gens_h: Vec<RistrettoPoint> = gens.h_iter(n, m).copied().collect();
-
-            let resized_g: Vec<RistrettoPoint> = gen_resized.g_iter(n, m).copied().collect();
-            let resized_h: Vec<RistrettoPoint> = gen_resized.h_iter(n, m).copied().collect();
-
-            assert_eq!(gens_g, resized_g);
-            assert_eq!(gens_h, resized_h);
-        };
-
-        helper(64, 8);
-        helper(32, 8);
-        helper(16, 8);
-    }
 }

--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -10,13 +10,13 @@ use zeroize::Zeroize;
 use crate::{
     errors::ProofError,
     range_parameters::RangeParameters,
-    traits::{Compressable, FromUniformBytes},
+    traits::{Compressable, FromUniformBytes, Precomputable},
 };
 
 /// The range proof statement contains the generators, vector of commitments, vector of optional minimum promised
 /// values and a vector of optional seed nonces for mask recovery
 #[derive(Clone)]
-pub struct RangeStatement<P: Compressable> {
+pub struct RangeStatement<P: Compressable + Precomputable> {
     /// The generators and base points needed for aggregating range proofs
     pub generators: RangeParameters<P>,
     /// The aggregated commitments
@@ -29,7 +29,7 @@ pub struct RangeStatement<P: Compressable> {
     pub seed_nonce: Option<Scalar>,
 }
 
-impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
+impl<P: Compressable + FromUniformBytes + Clone + Precomputable> RangeStatement<P> {
     /// Initialize a new 'RangeStatement' with sanity checks
     pub fn init(
         generators: RangeParameters<P>,
@@ -72,7 +72,7 @@ impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
 }
 
 /// Overwrite secrets with null bytes when they go out of scope.
-impl<P: Compressable> Drop for RangeStatement<P> {
+impl<P: Compressable + Precomputable> Drop for RangeStatement<P> {
     fn drop(&mut self) {
         self.seed_nonce.zeroize();
     }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -7,14 +7,14 @@
 
 use curve25519_dalek::{
     constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
-    ristretto::{CompressedRistretto, RistrettoPoint},
+    ristretto::{CompressedRistretto, RistrettoPoint, VartimeRistrettoPrecomputation},
 };
 
 use crate::{
     generators::pedersen_gens::ExtensionDegree,
     protocols::curve_point_protocol::CurvePointProtocol,
     range_proof::RangeProof,
-    traits::{Compressable, Decompressable, FixedBytesRepr, FromUniformBytes},
+    traits::{Compressable, Decompressable, FixedBytesRepr, FromUniformBytes, Precomputable},
     PedersenGens,
 };
 
@@ -53,6 +53,10 @@ impl Compressable for RistrettoPoint {
     fn compress(&self) -> Self::Compressed {
         RistrettoPoint::compress(self)
     }
+}
+
+impl Precomputable for RistrettoPoint {
+    type Precomputation = VartimeRistrettoPrecomputation;
 }
 
 /// Create extended Pedersen generators for the required extension degree using pre-calculated compressed constants

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use curve25519_dalek::traits::VartimePrecomputedMultiscalarMul;
+
 /// Abstrations for any type that can be represented as 32 bytes
 pub trait FixedBytesRepr {
     /// Returns a reference to the 32-byte representation
@@ -32,4 +34,10 @@ pub trait Decompressable {
 
     /// Try decompress this instance. None is returned if this fails.
     fn decompress(&self) -> Option<Self::Decompressed>;
+}
+
+/// Abstraction for any type supporting multiscalar multiplication precomputation
+pub trait Precomputable {
+    /// The type representing the precomputation instantiation
+    type Precomputation: Clone + VartimePrecomputedMultiscalarMul<Point = Self>;
 }

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::ProofError,
     protocols::transcript_protocol::TranscriptProtocol,
     range_statement::RangeStatement,
-    traits::{Compressable, FixedBytesRepr},
+    traits::{Compressable, FixedBytesRepr, Precomputable},
 };
 
 // Helper function to construct the initial transcript
@@ -22,7 +22,7 @@ pub(crate) fn transcript_initialize<P>(
     statement: &RangeStatement<P>,
 ) -> Result<(), ProofError>
 where
-    P: Compressable,
+    P: Compressable + Precomputable,
     P::Compressed: FixedBytesRepr + IsIdentity,
 {
     transcript.validate_and_append_point(b"H", h_base_compressed)?;


### PR DESCRIPTION
Uses precomputation of fixed generator vectors to speed up verification, at the cost of storing precomputation tables between verification operations. This doesn't use precomputation on the Pedersen generators, since those can be set independently of the others, and we can't mix-and-match precomputation tables due to upstream limitations.

Note that this requires and uses a custom curve library fork. The fork supports partial precomputation by removing an existing restriction about matching the number of static points and scalars used for precomputation evaluation. It also implements `Clone` on the underlying types used for precomputation. This is unfortunate, since due to their size (several megabytes in total) such tables should almost certainly never be cloned. However, it's done for the reason explained below.

The generator tables are wrapped in an `Arc` for shared ownership. This is done because precomputation evaluation is an instance method on a precomputation type, not a static method that takes a reference to the underlying tables. I have no idea why this design was chosen (static methods are used for other types of multiscalar multiplication), especially because there's no mutation involved. But because of this, the verifier needs to own the precomputation structure containing the tables, even though those tables are expected to be reused (that's the entire point of precomputation). Using an `Arc` takes care of this nicely, and avoids cloning.

However, apparently `#[derive(Clone)]` only plays nicely with structs if all included generic types implement `Clone`, which means even though cloning the table `Arc` isn't any kind of deep copy, we can't use that attribute unless the precomputation tables implement `Clone`. Manually implementing `Clone` on the containing struct is a headache, so it seemed easier just to add `#[derive(Clone)]` at the curve library level.

This means it's probably _very important_ to ensure that precomputation tables are used very carefully to avoid unintended cloning. I did some testing and confirmed that the current implementation handles this as expected, and won't clone any of the tables, despite the compiler requiring they implement `Clone`.

Closes [issue #18](https://github.com/tari-project/bulletproofs-plus/issues/18).