### PR TITLE
feat!: split batches for verification

### DIFF
--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -169,7 +169,8 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             // Benchmark this code
             b.iter(|| {
                 // 5. Verify the aggregated proof
-                let _masks = RangeProof::verify_do_not_recover_masks(transcript_label, &statements, &proofs).unwrap();
+                let _masks =
+                    RangeProof::verify_batch(transcript_label, &statements, &proofs, VerifyAction::VerifyOnly).unwrap();
             });
         });
     }
@@ -251,11 +252,22 @@ fn verify_batched_rangeproofs_helper(bit_length: usize, extension_degree: Extens
                     // 5. Verify the entire batch of single proofs
                     match extract_masks {
                         VerifyAction::VerifyOnly => {
-                            let _masks =
-                                RangeProof::verify_do_not_recover_masks(transcript_label, statements, proofs).unwrap();
+                            let _masks = RangeProof::verify_batch(
+                                transcript_label,
+                                statements,
+                                proofs,
+                                VerifyAction::VerifyOnly,
+                            )
+                            .unwrap();
                         },
                         VerifyAction::RecoverOnly => {
-                            let _masks = RangeProof::recover_masks_ony(transcript_label, statements, proofs).unwrap();
+                            let _masks = RangeProof::verify_batch(
+                                transcript_label,
+                                statements,
+                                proofs,
+                                VerifyAction::RecoverOnly,
+                            )
+                            .unwrap();
                         },
                         _ => {},
                     }

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -64,6 +64,9 @@ pub struct RangeProof<P: Compressable> {
 /// The maximum bit length for which proofs can be generated
 pub const MAX_RANGE_PROOF_BIT_LENGTH: usize = 64;
 
+/// Maximum number of proofs in a batch
+const MAX_RANGE_PROOF_BATCH_SIZE: usize = 256;
+
 /// # Example
 /// ```
 /// use curve25519_dalek::scalar::Scalar;
@@ -160,13 +163,18 @@ pub const MAX_RANGE_PROOF_BIT_LENGTH: usize = 64;
 /// }
 ///
 /// // 5. Verify the entire batch as the commitment owner, i.e. the prover self
-/// let recovered_private_masks =
-///     RangeProof::verify_and_recover_masks(transcript_label, &statements_private, &proofs).unwrap();
+/// let recovered_private_masks = RangeProof::verify_batch(
+///     transcript_label,
+///     &statements_private,
+///     &proofs,
+///     VerifyAction::RecoverAndVerify,
+/// )
+/// .unwrap();
 /// assert_eq!(private_masks, recovered_private_masks);
 ///
 /// // 6. Verify the entire batch as public entity
 /// let recovered_public_masks =
-///     RangeProof::verify_do_not_recover_masks(transcript_label, &statements_public, &proofs).unwrap();
+///     RangeProof::verify_batch(transcript_label, &statements_public, &proofs, VerifyAction::VerifyOnly).unwrap();
 /// assert_eq!(public_masks, recovered_public_masks);
 ///
 /// # }
@@ -433,37 +441,38 @@ where
         Ok((max_mn, max_index))
     }
 
-    /// Verify a batch of single and/or aggregated range proofs as the commitment owner and recover the masks for single
-    /// range proofs by supplying the optional seed nonces
-    pub fn verify_and_recover_masks(
+    /// Wrapper function for batch verification in different modes: mask recovery, verification, or both
+    pub fn verify_batch(
         transcript_label: &'static str,
         statements: &[RangeStatement<P>],
-        range_proofs: &[RangeProof<P>],
+        proofs: &[RangeProof<P>],
+        action: VerifyAction,
     ) -> Result<Vec<Option<ExtendedMask>>, ProofError> {
-        RangeProof::verify(
-            transcript_label,
-            statements,
-            range_proofs,
-            VerifyAction::RecoverAndVerify,
-        )
-    }
+        // We need to check for size consistency here, even though it's also done later
+        if statements.len() != proofs.len() {
+            return Err(ProofError::InvalidArgument(
+                "Batch statement/proof size mismatch".to_string(),
+            ));
+        }
 
-    /// Verify a batch of single and/or aggregated range proofs as a public entity
-    pub fn verify_do_not_recover_masks(
-        transcript_label: &'static str,
-        statements: &[RangeStatement<P>],
-        range_proofs: &[RangeProof<P>],
-    ) -> Result<Vec<Option<ExtendedMask>>, ProofError> {
-        RangeProof::verify(transcript_label, statements, range_proofs, VerifyAction::VerifyOnly)
-    }
+        // Store masks from all results
+        let mut masks = Vec::<Option<ExtendedMask>>::with_capacity(proofs.len());
 
-    /// Recover the masks for single range proofs by supplying the optional seed nonces
-    pub fn recover_masks_ony(
-        transcript_label: &'static str,
-        statements: &[RangeStatement<P>],
-        range_proofs: &[RangeProof<P>],
-    ) -> Result<Vec<Option<ExtendedMask>>, ProofError> {
-        RangeProof::verify(transcript_label, statements, range_proofs, VerifyAction::RecoverOnly)
+        // Get chunks of both the statements and proofs
+        let mut chunks = statements
+            .chunks(MAX_RANGE_PROOF_BATCH_SIZE)
+            .zip(proofs.chunks(MAX_RANGE_PROOF_BATCH_SIZE))
+            .peekable();
+
+        // If the batch fails, propagate the error; otherwise, store the masks and keep going
+        if let Some((batch_statements, batch_proofs)) = chunks.next() {
+            let mut result = RangeProof::verify(transcript_label, batch_statements, batch_proofs, action)?;
+
+            masks.append(&mut result);
+        }
+
+        // Note that an empty batch succeeds
+        Ok(masks)
     }
 
     // Verify a batch of single and/or aggregated range proofs as a public entity, or recover the masks for single

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -467,8 +467,7 @@ where
         // Get chunks of both the statements and proofs
         let mut chunks = statements
             .chunks(MAX_RANGE_PROOF_BATCH_SIZE)
-            .zip(proofs.chunks(MAX_RANGE_PROOF_BATCH_SIZE))
-            .peekable();
+            .zip(proofs.chunks(MAX_RANGE_PROOF_BATCH_SIZE));
 
         // If the batch fails, propagate the error; otherwise, store the masks and keep going
         if let Some((batch_statements, batch_proofs)) = chunks.next() {

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -448,10 +448,16 @@ where
         proofs: &[RangeProof<P>],
         action: VerifyAction,
     ) -> Result<Vec<Option<ExtendedMask>>, ProofError> {
+        // By definition, an empty batch fails
+        if statements.is_empty() || proofs.is_empty() {
+            return Err(ProofError::InvalidArgument(
+                "Range statements or proofs length empty".to_string(),
+            ));
+        }
         // We need to check for size consistency here, even though it's also done later
         if statements.len() != proofs.len() {
             return Err(ProofError::InvalidArgument(
-                "Batch statement/proof size mismatch".to_string(),
+                "Range statements and proofs length mismatch".to_string(),
             ));
         }
 
@@ -471,7 +477,6 @@ where
             masks.append(&mut result);
         }
 
-        // Note that an empty batch succeeds
         Ok(masks)
     }
 

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -65,6 +65,8 @@ pub struct RangeProof<P: Compressable> {
 pub const MAX_RANGE_PROOF_BIT_LENGTH: usize = 64;
 
 /// Maximum number of proofs in a batch
+/// This is only for performance reasons, where a very large batch can see diminishing returns
+/// There is no theoretical limit imposed by the algorithms!
 const MAX_RANGE_PROOF_BATCH_SIZE: usize = 256;
 
 /// # Example


### PR DESCRIPTION
Splits batches during verification. Updates the API to require callers to specify a verification action.

Closes [issue #21](https://github.com/tari-project/bulletproofs-plus/issues/21).

BREAKING CHANGE: Changes the verification API.