### PR TITLE
fix: fix rand_core inequality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ derive_more = "0.99.17"
 derivative = "2.2.0"
 digest = { version = "0.9.0", default-features = false }
 lazy_static = "1.4.0"
-merlin = { version = "3", default-features = false }
+merlin = { version = "2", default-features = false }
 rand = "0.7"
 # Note: toolchain must be at v1.60+ to support serde v1.0.150+
 serde = "1.0.150"


### PR DESCRIPTION
`merlin = "3"` uses `rand_core = "6"` instead of `rand_core = "5"` like the rest of the code base