### PR TITLE
feat!: proof offloading

### DIFF
--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -83,8 +83,8 @@ fn create_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             // 3. Generate the statement
             let seed_nonce_pair = if aggregation_factor == 1 {
                 Some(RangeSeedNonce {
-                    seed_nonce: Scalar::random(&mut rng),
-                    seed_nonce_alpha: Scalar::random(&mut rng),
+                    seed_nonce_helper: rng.gen::<[u8; 32]>().to_vec(),
+                    seed_nonce_signer: rng.gen::<[u8; 32]>().to_vec(),
                 })
             } else {
                 None
@@ -153,8 +153,8 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             // 3. Generate the statement
             let seed_nonce_pair = if aggregation_factor == 1 {
                 Some(RangeSeedNonce {
-                    seed_nonce: Scalar::random(&mut rng),
-                    seed_nonce_alpha: Scalar::random(&mut rng),
+                    seed_nonce_helper: rng.gen::<[u8; 32]>().to_vec(),
+                    seed_nonce_signer: rng.gen::<[u8; 32]>().to_vec(),
                 })
             } else {
                 None
@@ -233,8 +233,8 @@ fn verify_batched_rangeproofs_helper(bit_length: usize, extension_degree: Extens
 
         // 3. Generate the statement
         let seed_nonce_pair = Some(RangeSeedNonce {
-            seed_nonce: Scalar::random(&mut rng),
-            seed_nonce_alpha: Scalar::random(&mut rng),
+            seed_nonce_helper: rng.gen::<[u8; 32]>().to_vec(),
+            seed_nonce_signer: rng.gen::<[u8; 32]>().to_vec(),
         });
         let statement = RangeStatement::init(
             generators.clone(),

--- a/lints.toml
+++ b/lints.toml
@@ -26,7 +26,7 @@ deny = [
     'clippy::else_if_without_else',
     'clippy::enum_glob_use',
     'clippy::inline_always',
-    'clippy::let_underscore_drop',
+    'let_underscore_drop',
     'clippy::let_unit_value',
     'clippy::match_on_vec_items',
     'clippy::match_wild_err_arm',

--- a/src/inner_product_round.rs
+++ b/src/inner_product_round.rs
@@ -52,7 +52,7 @@ pub struct InnerProductRound<'a, P> {
 
     // Seed for mask recovery
     round: usize,
-    seed_nonce: Option<Scalar>,
+    seed_nonce_helper: Option<Vec<u8>>,
 }
 
 impl<'a, P: 'a> InnerProductRound<'a, P>
@@ -74,7 +74,7 @@ where
         alpha: Vec<Scalar>,
         y_powers: Vec<Scalar>,
         transcript: &'a mut Transcript,
-        seed_nonce: Option<Scalar>,
+        seed_nonce_helper: Option<Vec<u8>>,
         aggregation_factor: usize,
     ) -> Result<Self, ProofError> {
         let n = gi_base.len();
@@ -112,7 +112,7 @@ where
             ri: Vec::with_capacity(n * aggregation_factor + 2),
             transcript: transcript.into(),
             round: 0,
-            seed_nonce,
+            seed_nonce_helper,
         })
     }
 
@@ -130,10 +130,10 @@ where
                 Vec::with_capacity(extension_degree),
                 Vec::with_capacity(extension_degree),
             );
-            if let Some(seed_nonce) = self.seed_nonce {
+            if let Some(seed_nonce_helper) = &self.seed_nonce_helper {
                 for k in 0..extension_degree {
-                    d.push((nonce(&seed_nonce, "d", None, Some(k)))?);
-                    eta.push((nonce(&seed_nonce, "eta", None, Some(k)))?);
+                    d.push((nonce(seed_nonce_helper, "d", None, Some(k)))?);
+                    eta.push((nonce(seed_nonce_helper, "eta", None, Some(k)))?);
                 }
             } else {
                 for _k in 0..extension_degree {
@@ -188,10 +188,10 @@ where
             Vec::with_capacity(extension_degree),
             Vec::with_capacity(extension_degree),
         );
-        if let Some(seed_nonce) = self.seed_nonce {
+        if let Some(seed_nonce_helper) = &self.seed_nonce_helper {
             for k in 0..extension_degree {
-                d_l.push((nonce(&seed_nonce, "dL", Some(self.round), Some(k)))?);
-                d_r.push((nonce(&seed_nonce, "dR", Some(self.round), Some(k)))?);
+                d_l.push((nonce(seed_nonce_helper, "dL", Some(self.round), Some(k)))?);
+                d_r.push((nonce(seed_nonce_helper, "dR", Some(self.round), Some(k)))?);
             }
         } else {
             for _k in 0..extension_degree {
@@ -357,6 +357,6 @@ impl<'a, P> Drop for InnerProductRound<'a, P> {
             item.zeroize();
         }
         self.alpha.zeroize();
-        self.seed_nonce.zeroize();
+        self.seed_nonce_helper.zeroize();
     }
 }

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -533,6 +533,13 @@ where
         witness: &RangeWitness,
         seed_nonce_pair: &Option<RangeSeedNonce>,
     ) -> Result<Self, ProofError> {
+        // Sanity check input data
+        if witness.extension_degree != statement.generators.extension_degree() {
+            return Err(ProofError::InvalidArgument(
+                "Witness and statement extension degrees do not match!".to_string(),
+            ));
+        }
+
         // Extract the seed nonces for separation
         let seed_nonce_helper = seed_nonce_pair.as_ref().map(|p| p.seed_nonce_helper.clone());
         let seed_nonce_signer = seed_nonce_pair.as_ref().map(|p| p.seed_nonce_signer.clone());

--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -4,7 +4,6 @@
 //! Bulletproofs+ generators, vector of commitments, vector of optional minimum promised
 //! values and a vector of optional seed nonces for mask recovery
 
-use curve25519_dalek::scalar::Scalar;
 use zeroize::Zeroize;
 
 use crate::{
@@ -67,15 +66,15 @@ impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
 #[derive(Clone)]
 pub struct RangeSeedNonce {
     /// The seed nonce used for the helper's values
-    pub seed_nonce: Scalar,
+    pub seed_nonce_helper: Vec<u8>,
     /// The seed nonce used for the signer's value
-    pub seed_nonce_alpha: Scalar,
+    pub seed_nonce_signer: Vec<u8>,
 }
 
 /// Treat nonce seeds as secret data
 impl Drop for RangeSeedNonce {
     fn drop(&mut self) {
-        self.seed_nonce.zeroize();
-        self.seed_nonce_alpha.zeroize();
+        self.seed_nonce_helper.zeroize();
+        self.seed_nonce_signer.zeroize();
     }
 }

--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -64,6 +64,7 @@ impl<P: Compressable + FromUniformBytes + Clone> RangeStatement<P> {
 
 /// Range statements may come equipped with seed nonce pairs used for mask extraction by a designated verifier
 /// They are kept separate from the statement to simplify proving operations
+#[derive(Clone)]
 pub struct RangeSeedNonce {
     /// The seed nonce used for the helper's values
     pub seed_nonce: Scalar,

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -19,8 +19,8 @@ pub(crate) fn transcript_initialize<P>(
     bit_length: usize,
     extension_degree: usize,
     aggregation_factor: usize,
-    commitments: &Vec<P::Compressed>,
-    minimum_value_promises: &Vec<Option<u64>>,
+    commitments: &[P::Compressed],
+    minimum_value_promises: &[Option<u64>],
 ) -> Result<(), ProofError>
 where
     P: Compressable,

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -7,11 +7,11 @@ use merlin::Transcript;
 use crate::{
     errors::ProofError,
     protocols::transcript_protocol::TranscriptProtocol,
-    range_statement::RangeStatement,
     traits::{Compressable, FixedBytesRepr},
 };
 
 // Helper function to construct the initial transcript
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn transcript_initialize<P>(
     transcript: &mut Transcript,
     h_base_compressed: &P::Compressed,
@@ -19,7 +19,8 @@ pub(crate) fn transcript_initialize<P>(
     bit_length: usize,
     extension_degree: usize,
     aggregation_factor: usize,
-    statement: &RangeStatement<P>,
+    commitments: &Vec<P::Compressed>,
+    minimum_value_promises: &Vec<Option<u64>>,
 ) -> Result<(), ProofError>
 where
     P: Compressable,
@@ -32,10 +33,10 @@ where
     transcript.append_u64(b"N", bit_length as u64);
     transcript.append_u64(b"T", extension_degree as u64);
     transcript.append_u64(b"M", aggregation_factor as u64);
-    for item in &statement.commitments_compressed {
+    for item in commitments {
         transcript.append_point(b"Ci", item);
     }
-    for item in &statement.minimum_value_promises {
+    for item in minimum_value_promises {
         if let Some(minimum_value) = item {
             transcript.append_u64(b"vi - minimum_value", *minimum_value);
         } else {

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -29,7 +29,7 @@ fn encode_usize(size: usize) -> Result<Vec<u8>, ProofError> {
 
 /// Create a Blake2B deterministic nonce given a seed, label and two indexes
 pub fn nonce(
-    seed_nonce: &Vec<u8>,
+    seed_nonce: &[u8],
     label: &str,
     index_j: Option<usize>,
     index_k: Option<usize>,
@@ -48,7 +48,7 @@ pub fn nonce(
 
     // Write the seed nonce with prepended length
     key.append(&mut encode_usize(seed_nonce.len())?);
-    key.append(&mut seed_nonce.clone());
+    key.append(&mut seed_nonce.to_vec());
 
     // If defined, write the j-index with prepended length
     if let Some(index) = index_j {

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -206,8 +206,8 @@ fn prove_and_verify(
             // 3. Generate the statement
             let seed_nonce_pair = if *aggregation_size == 1 {
                 Some(RangeSeedNonce {
-                    seed_nonce: Scalar::random(&mut rng),
-                    seed_nonce_alpha: Scalar::random(&mut rng),
+                    seed_nonce_helper: rng.gen::<[u8; 32]>().to_vec(),
+                    seed_nonce_signer: rng.gen::<[u8; 32]>().to_vec(),
                 })
             } else {
                 None
@@ -293,10 +293,10 @@ fn prove_and_verify(
                 let mut seed_nonce_pairs_changed = vec![];
                 for seed_nonce_pair in &seed_nonce_pairs {
                     match seed_nonce_pair {
-                        Some(seed_nonce_pair) => {
+                        Some(_) => {
                             seed_nonce_pairs_changed.push(Some(RangeSeedNonce {
-                                seed_nonce: seed_nonce_pair.seed_nonce + Scalar::one(),
-                                seed_nonce_alpha: seed_nonce_pair.seed_nonce_alpha + Scalar::one(),
+                                seed_nonce_helper: rng.gen::<[u8; 32]>().to_vec(),
+                                seed_nonce_signer: rng.gen::<[u8; 32]>().to_vec(),
                             }));
                         },
                         None => seed_nonce_pairs_changed.push(None),


### PR DESCRIPTION
A [recent issue](https://github.com/tari-project/bulletproofs-plus/issues/27) suggests a design for proof offloading. This PR implements it using a state machine design with a wrapper for existing proving functionality. Closes [issue 27](https://github.com/tari-project/bulletproofs-plus/issues/27).

The linked design assumes that a signer (who knows commitment masks) and a helper (who only knows the commitment values and commitments) want to collaborate to produce a range proof. We implement their interaction using an informal state machine, where each state transition consumes input message data and a previous state, and generates output message data and a new state. This means that both the signer and helper need the capability to retain this state during the proof generation process.

Because the signer does not want the helper to be able to obtain the mask, we add an additional seed nonce. The signer uses one seed nonce during its operations, and the helper uses the other. During verification, a designated verifier who knows both seeds can extract the mask. To help make this work more cleanly, we move the seed nonces to their own separate `RangeSeedNonce`, which is no longer part of `RangeStatement`. This also seems more in line with the functioning of seed nonces, which aren't strictly part of the range statement for non-designated verifiers. We also change each of the seed nonces to be a byte vector, which is more generic.

We keep the existing proving functionality, where the signer and helper are the same entity. This is accomplished by the use of a simple wrapper that executes the state machine transitions for the signer and helper itself, and keeps the code cleaner.

Note that the linked design has security implications relating to rewinding attacks. The state machine design is intended to help mitigate these, but any nontrivial implementations should carefully consider the implications of such attacks.

BREAKING CHANGE: Changes the prover and verifier APIs. Updates how seed nonces are used in mask recovery. Existing range proofs using seed nonces will fail to recover masks.