### PR TITLE
fix!: nonce index encoding

### DIFF
--- a/lints.toml
+++ b/lints.toml
@@ -26,7 +26,7 @@ deny = [
     'clippy::else_if_without_else',
     'clippy::enum_glob_use',
     'clippy::inline_always',
-    'clippy::let_underscore_drop',
+    'let_underscore_drop',
     'clippy::let_unit_value',
     'clippy::match_on_vec_items',
     'clippy::match_wild_err_arm',


### PR DESCRIPTION
Nonces used for mask recovery are generated using hashes of a label, seed, and two optional indexes. The label is included using the `persona` field available in `Blake2b`, and the seed is of fixed length. However, the indexes are `usize` and encoded in a manner that is platform dependent. This means that mask recovery on a platform with a different pointer size than the prover will fail to produce the correct mask.

This work updates to use a `u32` encoding, returning an error if the index exceeds this limit. This should never occur, given the typical range of indexes used. It adds tests and does some minor refactoring.

Closes [issue 30](https://github.com/tari-project/bulletproofs-plus/issues/30).

BREAKING CHANGE: Changes the way that seed nonces are used in mask recovery. Existing range proofs will verify, but will fail to recover the correct mask.