### PR TITLE
feat: simplify bit vector commitment

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -262,14 +262,10 @@ where
                 Scalar::random_not_zero(rng)
             });
         }
-        let a = P::vartime_multiscalar_mul(
-            alpha.iter().chain(a_li.iter()).chain(a_ri.iter()),
-            statement
-                .generators
-                .g_bases()
-                .iter()
-                .chain(statement.generators.gi_base_iter())
-                .chain(statement.generators.hi_base_iter()),
+        let a = statement.generators.precomp().vartime_mixed_multiscalar_mul(
+            a_li.iter().interleave(a_ri.iter()),
+            alpha.iter(),
+            statement.generators.g_bases().iter(),
         );
 
         // Get challenges


### PR DESCRIPTION
Currently, bit vector commitments are computed using [multiscalar multiplication](https://github.com/tari-project/bulletproofs-plus/blob/cd7588ee8eaebe862fe9cf5d7c3fd92981703e87/src/range_proof.rs#L265-L273) against the inner-product generators. However, this can be simplified by using the shiny new [generator precomputation](https://github.com/tari-project/bulletproofs-plus/pull/19) feature.