### PR TITLE
chore: update curve library and dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --features u64_backend
+          args: --all-features
       - name: bench
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,26 +7,26 @@ license = "BSD-3-Clause"
 description = "A smaller faster implementation of Bulletproofs"
 
 [dependencies]
-blake2 = "0.9.1"
+blake2 = "0.10"
 byteorder = { version = "1", default-features = false }
 curve25519-dalek = { git = "https://github.com/AaronFeickert/curve25519-dalek.git", branch = "upstream-partial-precomp", features = ["serde", "rand_core"] } # TODO: change when updated upstream
-derive_more = "0.99.17"
-derivative = "2.2.0"
-digest = { version = "0.9.0", default-features = false }
-itertools = "0.6.0"
-lazy_static = "1.4.0"
-merlin = { version = "2", default-features = false }
+derive_more = "0.99"
+derivative = "2.2"
+digest = { version = "0.10", default-features = false }
+itertools = "0.6"
+lazy_static = "1.4"
+merlin = { version = "3", default-features = false }
 rand = "0.8"
 # Note: toolchain must be at v1.60+ to support serde v1.0.150+
-serde = "1.0.150"
-sha3 = { version = "0.9.1", default-features = false }
+serde = "1.0"
+sha3 = { version = "0.10", default-features = false }
 thiserror = { version = "1" }
 zeroize = "1"
 rand_core = "0.6"
 
 [dev-dependencies]
 bincode = "1"
-criterion = "0.3"
+criterion = "0.5"
 
 [[bench]]
 name = "range_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = "0.10"
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package = "tari-curve25519-dalek", git = "https://github.com/tari-project/curve25519-dalek.git", rev = "d727ce3c055c5d99980ffa9ffe43c6c8e934dca3", features = ["serde", "rand_core"] }
+curve25519-dalek = { package = "tari-curve25519-dalek", git = "https://github.com/tari-project/curve25519-dalek.git", tag = "v4.0.0-tarirc.3", features = ["serde", "rand_core"] }
 derive_more = "0.99"
 derivative = "2.2"
 digest = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = "0.10"
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { git = "https://github.com/AaronFeickert/curve25519-dalek.git", branch = "upstream-partial-precomp", features = ["serde", "rand_core"] } # TODO: change when updated upstream
+curve25519-dalek = { package = "tari-curve25519-dalek", git = "https://github.com/tari-project/curve25519-dalek.git", rev = "d727ce3c055c5d99980ffa9ffe43c6c8e934dca3", features = ["serde", "rand_core"] }
 derive_more = "0.99"
 derivative = "2.2"
 digest = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,34 +9,28 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = "0.9.1"
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package="tari-curve25519-dalek", version = "4.0.2", default-features = false, features = ["serde", "alloc"] }
+curve25519-dalek = { git = "https://github.com/AaronFeickert/curve25519-dalek.git", branch = "upstream-partial-precomp", features = ["serde", "rand_core"] } # TODO: change when updated upstream
 derive_more = "0.99.17"
 derivative = "2.2.0"
 digest = { version = "0.9.0", default-features = false }
 itertools = "0.6.0"
 lazy_static = "1.4.0"
 merlin = { version = "2", default-features = false }
-rand = "0.7"
+rand = "0.8"
 # Note: toolchain must be at v1.60+ to support serde v1.0.150+
 serde = "1.0.150"
 sha3 = { version = "0.9.1", default-features = false }
 thiserror = { version = "1" }
 zeroize = "1"
-rand_core = { version = "0.5", default-features = false }
+rand_core = "0.6"
 
 [dev-dependencies]
 bincode = "1"
 criterion = "0.3"
 
-[features]
-default = ["u64_backend"]
-u64_backend = ["curve25519-dalek/u64_backend"]
-simd_backend = ["curve25519-dalek/simd_backend"]
-
 [[bench]]
 name = "range_proof"
 harness = false
-#required-features = ["simd_backend"]
 
 [[bench]]
 name = "generators"

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -65,7 +65,7 @@ fn create_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             let mut openings = vec![];
             let mut rng = rand::thread_rng();
             for _ in 0..aggregation_factor {
-                let value = rng.gen_range(value_min, value_max);
+                let value = rng.gen_range(value_min..=value_max);
                 minimum_values.push(Some(value / 3));
                 let blindings = vec![Scalar::random_not_zero(&mut rng); extension_degree as usize];
                 commitments.push(
@@ -124,7 +124,7 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             bit_length, aggregation_factor, extension_degree
         );
         group.bench_function(&label, move |b| {
-            // 0.  Batch data
+            // 0. Batch data
             let mut statements = vec![];
             let mut proofs = vec![];
 
@@ -137,7 +137,7 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             let mut openings = vec![];
             let mut rng = rand::thread_rng();
             for _ in 0..aggregation_factor {
-                let value = rng.gen_range(value_min, value_max);
+                let value = rng.gen_range(value_min..=value_max);
                 minimum_values.push(Some(value / 3));
                 let blindings = vec![Scalar::random_not_zero(&mut rng); extension_degree as usize];
                 commitments.push(
@@ -216,7 +216,7 @@ fn verify_batched_rangeproofs_helper(bit_length: usize, extension_degree: Extens
                 for _ in 0..number_of_range_proofs {
                     // Witness data
                     let mut openings = vec![];
-                    let value = rng.gen_range(value_min, value_max);
+                    let value = rng.gen_range(value_min..=value_max);
                     let blindings = vec![Scalar::random_not_zero(&mut rng); extension_degree as usize];
                     openings.push(CommitmentOpening::new(value, blindings.clone()));
                     let witness = RangeWitness::init(openings).unwrap();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,7 @@ pub enum ProofError {
     /// Invalid array/vector length error
     #[error("Invalid array/vector length error: `{0}`")]
     InvalidLength(String),
+    /// Invalid `Blake2b` hash operation
     #[error("Invalid Blake2b")]
     InvalidBlake2b,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,4 +17,6 @@ pub enum ProofError {
     /// Invalid array/vector length error
     #[error("Invalid array/vector length error: `{0}`")]
     InvalidLength(String),
+    #[error("Invalid Blake2b")]
+    InvalidBlake2b,
 }

--- a/src/generators/bulletproof_gens.rs
+++ b/src/generators/bulletproof_gens.rs
@@ -6,7 +6,7 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    sync::Arc,
+    rc::Rc,
 };
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -48,7 +48,7 @@ pub struct BulletproofGens<P: Precomputable> {
     /// Precomputed \\(\mathbf H\\) generators for each party.
     pub(crate) h_vec: Vec<Vec<P>>,
     /// Interleaved precomputed generators
-    pub(crate) precomp: Arc<P::Precomputation>,
+    pub(crate) precomp: Rc<P::Precomputation>,
 }
 
 impl<P: FromUniformBytes + Precomputable> BulletproofGens<P> {
@@ -82,7 +82,7 @@ impl<P: FromUniformBytes + Precomputable> BulletproofGens<P> {
         let iter_g_vec = g_vec.iter().flat_map(move |g_j| g_j.iter());
         let iter_h_vec = h_vec.iter().flat_map(move |h_j| h_j.iter());
         let iter_interleaved = iter_g_vec.interleave(iter_h_vec);
-        let precomp = Arc::new(P::Precomputation::new(iter_interleaved));
+        let precomp = Rc::new(P::Precomputation::new(iter_interleaved));
 
         BulletproofGens {
             gens_capacity,

--- a/src/generators/generators_chain.rs
+++ b/src/generators/generators_chain.rs
@@ -6,15 +6,15 @@
 
 use std::marker::PhantomData;
 
-use digest::{ExtendableOutputDirty, Update, XofReader};
-use sha3::{Sha3XofReader, Shake256};
+use digest::{core_api::XofReaderCoreWrapper, ExtendableOutput, Update, XofReader};
+use sha3::{Shake256, Shake256ReaderCore};
 
 use crate::traits::FromUniformBytes;
 
 /// The `GeneratorsChain` creates an arbitrary-long sequence of orthogonal generators.  The sequence can be
 /// deterministically produced starting with an arbitrary point.
 pub struct GeneratorsChain<P> {
-    reader: Sha3XofReader,
+    reader: XofReaderCoreWrapper<Shake256ReaderCore>,
     _phantom: PhantomData<P>,
 }
 
@@ -26,7 +26,7 @@ impl<P> GeneratorsChain<P> {
         shake.update(label);
 
         GeneratorsChain {
-            reader: shake.finalize_xof_dirty(),
+            reader: shake.finalize_xof(),
             _phantom: PhantomData,
         }
     }

--- a/src/inner_product_round.rs
+++ b/src/inner_product_round.rs
@@ -176,7 +176,7 @@ where
         let gi_base_hi = &self.gi_base[n..];
         let hi_base_lo = &self.hi_base[..n];
         let hi_base_hi = &self.hi_base[n..];
-        let y_n_inverse = if self.y_powers[n] == Scalar::zero() {
+        let y_n_inverse = if self.y_powers[n] == Scalar::ZERO {
             return Err(ProofError::InvalidArgument(
                 "Cannot invert a zero valued Scalar".to_string(),
             ));
@@ -204,8 +204,8 @@ where
         };
         self.round += 1;
 
-        let mut c_l = Scalar::zero();
-        let mut c_r = Scalar::zero();
+        let mut c_l = Scalar::ZERO;
+        let mut c_r = Scalar::ZERO;
         for i in 0..n {
             c_l += a1[i] * self.y_powers[i + 1] * b2[i];
             c_r += a2[i] * self.y_powers[n + i + 1] * b1[i];

--- a/src/protocols/scalar_protocol.rs
+++ b/src/protocols/scalar_protocol.rs
@@ -31,7 +31,7 @@ impl ScalarProtocol for Scalar {
     fn random_not_zero<R: RngCore + CryptoRng>(rng: &mut R) -> Scalar {
         loop {
             let value = Scalar::random(rng);
-            if value != Scalar::zero() {
+            if value != Scalar::ZERO {
                 return value;
             }
         }

--- a/src/protocols/scalar_protocol.rs
+++ b/src/protocols/scalar_protocol.rs
@@ -3,9 +3,9 @@
 
 //! Bulletproofs+ `ScalarProtocol` trait for using a Scalar
 
-use blake2::Blake2b;
+use blake2::Blake2bMac512;
 use curve25519_dalek::scalar::Scalar;
-use digest::Digest;
+use digest::FixedOutput;
 use rand::{CryptoRng, RngCore};
 
 use crate::errors::ProofError;
@@ -16,7 +16,7 @@ pub trait ScalarProtocol {
     fn random_not_zero<R: RngCore + CryptoRng>(rng: &mut R) -> Scalar;
 
     /// Construct a scalar from an existing Blake2b instance (helper function to implement 'Scalar::from_hash<Blake2b>')
-    fn from_hasher_blake2b(hasher: Blake2b) -> Scalar;
+    fn from_hasher_blake2b(hasher: Blake2bMac512) -> Scalar;
 
     /// Helper function to multiply one scalar vector with another scalar vector
     fn mul_scalar_vec_with_scalar(scalar_vec: &[Scalar], scalar: &Scalar) -> Result<Vec<Scalar>, ProofError>;
@@ -37,9 +37,9 @@ impl ScalarProtocol for Scalar {
         }
     }
 
-    fn from_hasher_blake2b(hasher: Blake2b) -> Scalar {
+    fn from_hasher_blake2b(hasher: Blake2bMac512) -> Scalar {
         let mut output = [0u8; 64];
-        output.copy_from_slice(hasher.finalize().as_slice());
+        output.copy_from_slice(hasher.finalize_fixed().as_slice());
         Scalar::from_bytes_mod_order_wide(&output)
     }
 

--- a/src/protocols/transcript_protocol.rs
+++ b/src/protocols/transcript_protocol.rs
@@ -66,7 +66,7 @@ impl TranscriptProtocol for Transcript {
         let mut buf = [0u8; 64];
         self.challenge_bytes(label, &mut buf);
         let value = Scalar::from_bytes_mod_order_wide(&buf);
-        if value == Scalar::zero() {
+        if value == Scalar::ZERO {
             Err(ProofError::VerificationFailed(
                 "Transcript challenge cannot be zero".to_string(),
             ))

--- a/src/range_parameters.rs
+++ b/src/range_parameters.rs
@@ -5,7 +5,7 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    sync::Arc,
+    rc::Rc,
 };
 
 use crate::{
@@ -121,10 +121,10 @@ where P: FromUniformBytes + Compressable + Clone + Precomputable
     }
 
     /// Return the interleaved precomputation tables
-    pub fn precomp(&self) -> Arc<P::Precomputation> {
+    pub fn precomp(&self) -> Rc<P::Precomputation> {
         // We use shared ownership since precomputation evaluation is an instance method and we don't want to actually
         // clone
-        Arc::clone(&self.bp_gens.precomp)
+        Rc::clone(&self.bp_gens.precomp)
     }
 }
 

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -247,7 +247,7 @@ where
             };
             for bit_field in bit_vector.clone() {
                 a_li.push(bit_field);
-                a_ri.push(bit_field - Scalar::one());
+                a_ri.push(bit_field - Scalar::ONE);
             }
         }
 
@@ -274,7 +274,7 @@ where
 
         // Compute powers of the challenge
         let mut y_powers = Vec::with_capacity(aggregation_factor * bit_length + 2);
-        y_powers.push(Scalar::one());
+        y_powers.push(Scalar::ONE);
         for _ in 1..(aggregation_factor * bit_length + 2) {
             y_powers.push(y_powers[y_powers.len() - 1] * y);
         }
@@ -300,7 +300,7 @@ where
             *item += d[i] * y_powers[bit_length * aggregation_factor - i] + z;
         }
         let mut alpha1 = alpha;
-        let mut z_even_powers = Scalar::one();
+        let mut z_even_powers = Scalar::ONE;
         for j in 0..aggregation_factor {
             z_even_powers *= z_square;
             for (k, alpha1_val) in alpha1.iter_mut().enumerate().take(extension_degree) {
@@ -495,13 +495,13 @@ where
         for _ in 0..log_n {
             two_n_minus_one = two_n_minus_one * two_n_minus_one;
         }
-        two_n_minus_one -= Scalar::one();
+        two_n_minus_one -= Scalar::ONE;
 
         // Weighted coefficients for common generators
-        let mut g_base_scalars = vec![Scalar::zero(); extension_degree];
-        let mut h_base_scalar = Scalar::zero();
-        let mut gi_base_scalars = vec![Scalar::zero(); max_mn];
-        let mut hi_base_scalars = vec![Scalar::zero(); max_mn];
+        let mut g_base_scalars = vec![Scalar::ZERO; extension_degree];
+        let mut h_base_scalar = Scalar::ZERO;
+        let mut gi_base_scalars = vec![Scalar::ZERO; max_mn];
+        let mut hi_base_scalars = vec![Scalar::ZERO; max_mn];
 
         // Final multiscalar multiplication data
         // Because we use precomputation on the generator vectors, we need to separate the static data from the dynamic
@@ -594,7 +594,7 @@ where
                 challenges_sq_inv.push(challenges_inv[i] * challenges_inv[i]);
             }
             let y_nm_1 = y_nm * y;
-            let mut y_sum = Scalar::zero();
+            let mut y_sum = Scalar::ZERO;
             let mut y_sum_temp = y;
             for _ in 0..bit_length * aggregation_factor {
                 y_sum += y_sum_temp;
@@ -654,7 +654,7 @@ where
             }
 
             // Aggregate the generator scalars
-            let mut y_inv_i = Scalar::one();
+            let mut y_inv_i = Scalar::ONE;
             let mut y_nm_i = y_nm;
 
             let mut s = Vec::with_capacity(gen_length);
@@ -676,7 +676,7 @@ where
             }
 
             // Remaining terms
-            let mut z_even_powers = Scalar::one();
+            let mut z_even_powers = Scalar::ONE;
             for minimum_value_promise in minimum_value_promises {
                 z_even_powers *= z_square;
                 let weighted = weight * (-e_square * z_even_powers * y_nm_1);
@@ -866,14 +866,17 @@ where
         let a = P::Compressed::from_fixed_bytes(read_32_bytes(&slice[pos..]));
         let a1 = P::Compressed::from_fixed_bytes(read_32_bytes(&slice[pos + 32..]));
         let b = P::Compressed::from_fixed_bytes(read_32_bytes(&slice[pos + 64..]));
-        let r1 = Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 96..]))
+        let r1 = Option::from(Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 96..])))
             .ok_or_else(|| ProofError::InvalidArgument("r1 bytes not a canonical byte representation".to_string()))?;
-        let s1 = Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 128..]))
+        let s1 = Option::from(Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 128..])))
             .ok_or_else(|| ProofError::InvalidArgument("s1 bytes not a canonical byte representation".to_string()))?;
         let mut d1 = Vec::with_capacity(extension_degree as usize);
         for i in 0..extension_degree as usize {
             d1.push(
-                Scalar::from_canonical_bytes(read_32_bytes(&slice[pos + 160 + i * 32..])).ok_or_else(|| {
+                Option::from(Scalar::from_canonical_bytes(read_32_bytes(
+                    &slice[pos + 160 + i * 32..],
+                )))
+                .ok_or_else(|| {
                     ProofError::InvalidArgument("d1 bytes not a canonical byte representation".to_string())
                 })?,
             );
@@ -955,7 +958,7 @@ mod tests {
     #[test]
     fn test_from_bytes() {
         assert!((RistrettoRangeProof::from_bytes(&[])).is_err());
-        assert!((RistrettoRangeProof::from_bytes(Scalar::zero().as_bytes().as_slice())).is_err());
+        assert!((RistrettoRangeProof::from_bytes(Scalar::ZERO.as_bytes().as_slice())).is_err());
         let proof = RistrettoRangeProof {
             a: Default::default(),
             a1: Default::default(),

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -700,9 +700,9 @@ where
             dynamic_points.push(a);
 
             dynamic_scalars.extend(challenges_sq.into_iter().map(|c| weight * -e_square * c));
-            dynamic_points.extend(li.into_iter());
+            dynamic_points.extend(li);
             dynamic_scalars.extend(challenges_sq_inv.into_iter().map(|c| weight * -e_square * c));
-            dynamic_points.extend(ri.into_iter());
+            dynamic_points.extend(ri);
         }
         if extract_masks == VerifyAction::RecoverOnly {
             return Ok(masks);

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -220,7 +220,7 @@ mod tests {
     fn test_commitments() {
         let mut rng = rand::thread_rng();
         let value = Scalar::random_not_zero(&mut rng);
-        let blindings = vec![
+        let blindings = [
             Scalar::random_not_zero(&mut rng),
             Scalar::random_not_zero(&mut rng),
             Scalar::random_not_zero(&mut rng),

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -15,7 +15,7 @@ use core::{
 };
 use std::convert::TryFrom;
 
-use blake2::Blake2b;
+use blake2::Blake2bMac512;
 use curve25519_dalek::scalar::Scalar;
 
 use crate::{errors::ProofError, protocols::scalar_protocol::ScalarProtocol, range_proof::MAX_RANGE_PROOF_BIT_LENGTH};
@@ -58,7 +58,8 @@ pub fn nonce(
         key.append(&mut b"k".to_vec()); // Domain separated index label (1 byte)
         key.append(&mut encode_usize(index)?); // Fixed length encoding of 'index_k' (4 bytes)
     }
-    let hasher = Blake2b::with_params(&key, &[], encoded_label);
+    let hasher =
+        Blake2bMac512::new_with_salt_and_personal(&key, &[], encoded_label).map_err(|_| ProofError::InvalidBlake2b)?;
 
     Ok(Scalar::from_hasher_blake2b(hasher))
 }

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -78,9 +78,9 @@ pub fn bit_vector_of_scalars(value: u64, bit_length: usize) -> Result<Vec<Scalar
     let mut result = Vec::with_capacity(bit_length);
     for i in 0..bit_length {
         if (value >> i) & 1 == 0 {
-            result.push(Scalar::zero());
+            result.push(Scalar::ZERO);
         } else {
-            result.push(Scalar::one());
+            result.push(Scalar::ONE);
         }
     }
     Ok(result)
@@ -214,7 +214,7 @@ mod tests {
         }
         let mut result = 0u128;
         for i in 0..bit_vector.len() as u128 {
-            if bit_vector[i as usize] == Scalar::one() {
+            if bit_vector[i as usize] == Scalar::ONE {
                 result += 1 << i;
             }
         }

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -156,7 +156,7 @@ fn prove_and_verify(
     let transcript_label: &'static str = "BatchedRangeProofTest";
 
     for bit_length in bit_lengths {
-        // 0.  Batch data
+        // 0. Batch data
         let mut private_masks: Vec<Option<ExtendedMask>> = vec![];
         let mut public_masks = vec![];
         let mut statements_private = vec![];
@@ -175,7 +175,7 @@ fn prove_and_verify(
             let mut commitments = vec![];
             let mut minimum_values = vec![];
             for m in 0..*aggregation_size {
-                let value = rng.gen_range(value_min, value_max);
+                let value = rng.gen_range(value_min..=value_max);
                 let minimum_value = match promise_strategy {
                     ProofOfMinimumValueStrategy::NoOffset => None,
                     ProofOfMinimumValueStrategy::Intermediate => Some(value / 3),
@@ -293,7 +293,7 @@ fn prove_and_verify(
                         commitments: statement.commitments.clone(),
                         commitments_compressed: statement.commitments_compressed.clone(),
                         minimum_value_promises: statement.minimum_value_promises.clone(),
-                        seed_nonce: statement.seed_nonce.map(|seed_nonce| seed_nonce + Scalar::one()),
+                        seed_nonce: statement.seed_nonce.map(|seed_nonce| seed_nonce + Scalar::ONE),
                     });
                 }
                 let recovered_private_masks_changed = RistrettoRangeProof::verify_batch(


### PR DESCRIPTION
Updates the curve library and associated dependencies.

One change of note is that precomputation tables are now maintained in an `Rc` instead of an `Arc` due to trait bounds.