### PR TITLE
chore: use crate reference for curve library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = "0.10"
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package = "tari-curve25519-dalek", git = "https://github.com/tari-project/curve25519-dalek.git", version = "4.0.3", features = ["serde", "rand_core"] }
+curve25519-dalek = { package = "tari-curve25519-dalek", version = "4.0.3", features = ["serde", "rand_core"] }
 derive_more = "0.99"
 derivative = "2.2"
 digest = { version = "0.10", default-features = false }


### PR DESCRIPTION
Update the curve library dependency to use a crate reference for consistency.

Closes #39.