### PR TITLE
feat: change precomputation `rc` to `arc`

### DIFF
--- a/src/generators/bulletproof_gens.rs
+++ b/src/generators/bulletproof_gens.rs
@@ -6,7 +6,7 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    rc::Rc,
+    sync::Arc,
 };
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -48,7 +48,7 @@ pub struct BulletproofGens<P: Precomputable> {
     /// Precomputed \\(\mathbf H\\) generators for each party.
     pub(crate) h_vec: Vec<Vec<P>>,
     /// Interleaved precomputed generators
-    pub(crate) precomp: Rc<P::Precomputation>,
+    pub(crate) precomp: Arc<P::Precomputation>,
 }
 
 impl<P: FromUniformBytes + Precomputable> BulletproofGens<P> {
@@ -82,7 +82,7 @@ impl<P: FromUniformBytes + Precomputable> BulletproofGens<P> {
         let iter_g_vec = g_vec.iter().flat_map(move |g_j| g_j.iter());
         let iter_h_vec = h_vec.iter().flat_map(move |h_j| h_j.iter());
         let iter_interleaved = iter_g_vec.interleave(iter_h_vec);
-        let precomp = Rc::new(P::Precomputation::new(iter_interleaved));
+        let precomp = Arc::new(P::Precomputation::new(iter_interleaved));
 
         BulletproofGens {
             gens_capacity,

--- a/src/range_parameters.rs
+++ b/src/range_parameters.rs
@@ -5,7 +5,7 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    rc::Rc,
+    sync::Arc,
 };
 
 use crate::{
@@ -121,10 +121,8 @@ where P: FromUniformBytes + Compressable + Clone + Precomputable
     }
 
     /// Return the interleaved precomputation tables
-    pub fn precomp(&self) -> Rc<P::Precomputation> {
-        // We use shared ownership since precomputation evaluation is an instance method and we don't want to actually
-        // clone
-        Rc::clone(&self.bp_gens.precomp)
+    pub fn precomp(&self) -> Arc<P::Precomputation> {
+        self.bp_gens.precomp.clone()
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -39,5 +39,5 @@ pub trait Decompressable {
 /// Abstraction for any type supporting multiscalar multiplication precomputation
 pub trait Precomputable {
     /// The type representing the precomputation instantiation
-    type Precomputation: Clone + VartimePrecomputedMultiscalarMul<Point = Self>;
+    type Precomputation: Send + Sync + Clone + VartimePrecomputedMultiscalarMul<Point = Self>;
 }


### PR DESCRIPTION
Changed Precomputation `Rc` to `Arc` as `Rc<VartimeRistrettoPrecomputation>` cannot be shared between threads safely