### PR TITLE
fix: reduce vector capacity

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -280,7 +280,7 @@ where
         }
 
         // Compute d efficiently
-        let mut d = Vec::with_capacity(bit_length + bit_length * aggregation_factor);
+        let mut d = Vec::with_capacity(bit_length * aggregation_factor);
         d.push(z_square);
         let two = Scalar::from(2u8);
         for i in 1..bit_length {
@@ -602,7 +602,7 @@ where
             }
 
             // Compute d efficiently
-            let mut d = Vec::with_capacity(bit_length + bit_length * aggregation_factor);
+            let mut d = Vec::with_capacity(bit_length * aggregation_factor);
             d.push(z_square);
             for i in 1..bit_length {
                 d.push(two * d[i - 1]);


### PR DESCRIPTION
When computing the `d` vector, the prover and verify each allocate too much space for it. This is unnecessary, since the number of scalar elements in the vector is known.

This PR fixes the over-allocation by correcting the requested capacity. This can be checked manually by examining the number of elements pushed to the vector in both the prover and verifier cases.