### PR TITLE
test: improve coverage

### DIFF
--- a/src/commitment_opening.rs
+++ b/src/commitment_opening.rs
@@ -42,3 +42,15 @@ impl Drop for CommitmentOpening {
         self.r.zeroize();
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_empty_blinding() {
+        let opening = CommitmentOpening::new(0u64, Vec::new());
+
+        assert!(opening.r_len().is_err());
+    }
+}

--- a/src/extended_mask.rs
+++ b/src/extended_mask.rs
@@ -36,3 +36,38 @@ impl ExtendedMask {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_assign() {
+        // Valid assignments
+        for degree in 1..=6 {
+            let blindings = vec![Scalar::ZERO; degree];
+            let extension = ExtensionDegree::try_from_size(degree).unwrap();
+
+            assert!(ExtendedMask::assign(extension, blindings).is_ok());
+        }
+
+        // Empty blinding vector
+        assert!(ExtendedMask::assign(ExtensionDegree::DefaultPedersen, Vec::new()).is_err());
+
+        // Extension degree mismatch
+        let blindings = vec![Scalar::ZERO];
+        assert!(ExtendedMask::assign(ExtensionDegree::AddTwoBasePoints, blindings).is_err());
+    }
+
+    #[test]
+    fn test_blindings() {
+        // Empty blinding vector; this shouldn't be possible
+        let mask = ExtendedMask { blindings: Vec::new() };
+        assert!(mask.blindings().is_err());
+
+        // Valid mask
+        let blindings = vec![Scalar::ZERO, Scalar::ONE];
+        let mask = ExtendedMask::assign(ExtensionDegree::AddOneBasePoint, blindings.clone()).unwrap();
+        assert_eq!(mask.blindings().unwrap(), blindings);
+    }
+}

--- a/src/protocols/curve_point_protocol.rs
+++ b/src/protocols/curve_point_protocol.rs
@@ -81,3 +81,22 @@ pub trait CurvePointProtocol:
         Ok(out)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use curve25519_dalek::RistrettoPoint;
+
+    use super::*;
+
+    #[test]
+    fn test_errors() {
+        // Empty point vector
+        assert!(RistrettoPoint::mul_point_vec_with_scalar(&[], &Scalar::ONE).is_err());
+
+        // Mismatched vector lengths
+        assert!(RistrettoPoint::add_point_vectors(&[RistrettoPoint::default()], &[]).is_err());
+
+        // Empty point vector
+        assert!(RistrettoPoint::add_point_vectors(&[], &[]).is_err());
+    }
+}

--- a/src/protocols/transcript_protocol.rs
+++ b/src/protocols/transcript_protocol.rs
@@ -16,9 +16,6 @@ pub trait TranscriptProtocol {
     /// Append a domain separator for the range proof with the given `label` and `message`.
     fn domain_separator(&mut self, label: &'static [u8], message: &[u8]);
 
-    /// Append a `scalar` with the given `label`.
-    fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
-
     /// Append a `point` with the given `label`.
     fn append_point<P: FixedBytesRepr>(&mut self, label: &'static [u8], point: &P);
 
@@ -37,10 +34,6 @@ pub trait TranscriptProtocol {
 impl TranscriptProtocol for Transcript {
     fn domain_separator(&mut self, label: &'static [u8], message: &[u8]) {
         self.append_message(label, message);
-    }
-
-    fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {
-        self.append_message(label, scalar.as_bytes());
     }
 
     fn append_point<P: FixedBytesRepr>(&mut self, label: &'static [u8], point: &P) {
@@ -73,5 +66,21 @@ impl TranscriptProtocol for Transcript {
         } else {
             Ok(value)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use curve25519_dalek::RistrettoPoint;
+    use merlin::Transcript;
+
+    use super::*;
+
+    #[test]
+    fn test_identity_point() {
+        let mut transcript = Transcript::new(b"test");
+        assert!(transcript
+            .validate_and_append_point(b"identity", &RistrettoPoint::default().compress())
+            .is_err());
     }
 }

--- a/src/range_parameters.rs
+++ b/src/range_parameters.rs
@@ -22,9 +22,9 @@ use crate::{
 #[derive(Clone)]
 pub struct RangeParameters<P: Compressable + Precomputable> {
     /// Generators needed for aggregating up to `m` range proofs of up to `n` bits each.
-    bp_gens: BulletproofGens<P>,
+    pub(crate) bp_gens: BulletproofGens<P>,
     /// The pair of base points for Pedersen commitments.
-    pc_gens: PedersenGens<P>,
+    pub(crate) pc_gens: PedersenGens<P>,
 }
 
 impl<P> RangeParameters<P>

--- a/src/range_parameters.rs
+++ b/src/range_parameters.rs
@@ -55,11 +55,6 @@ where P: FromUniformBytes + Compressable + Clone + Precomputable
         })
     }
 
-    /// Return a reference to the non-public bulletproof generators
-    pub fn bp_gens(&self) -> &BulletproofGens<P> {
-        &self.bp_gens
-    }
-
     /// Return a reference to the non-public base point generators
     pub fn pc_gens(&self) -> &PedersenGens<P> {
         &self.pc_gens
@@ -136,5 +131,26 @@ where
             .field("pc_gens", &self.pc_gens)
             .field("bp_gens", &self.bp_gens)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ristretto::create_pedersen_gens_with_extension_degree;
+
+    #[test]
+    fn test_init_errors() {
+        // Create some generators
+        let gens = create_pedersen_gens_with_extension_degree(ExtensionDegree::DefaultPedersen);
+
+        // Aggregation factor must be a power of two
+        RangeParameters::init(64, 3, gens.clone()).unwrap_err();
+
+        // Bit length must be a power of two
+        RangeParameters::init(3, 4, gens.clone()).unwrap_err();
+
+        // Bit length cannot be too large
+        RangeParameters::init(2 * MAX_RANGE_PROOF_BIT_LENGTH, 4, gens.clone()).unwrap_err();
     }
 }

--- a/src/range_witness.rs
+++ b/src/range_witness.rs
@@ -47,3 +47,25 @@ impl Drop for RangeWitness {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use curve25519_dalek::Scalar;
+
+    use super::*;
+
+    #[test]
+    fn test_init_errors() {
+        let s = Scalar::ZERO;
+
+        // Empty openings
+        assert!(RangeWitness::init(Vec::new()).is_err());
+
+        // Mismatched blinding factor lengths
+        let openings = vec![
+            CommitmentOpening::new(1u64, vec![s]),
+            CommitmentOpening::new(1u64, vec![s, s]),
+        ];
+        assert!(RangeWitness::init(openings).is_err());
+    }
+}

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -224,48 +224,22 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::match_wild_err_arm)]
     fn test_bit_vector() {
-        match bit_vector_of_scalars(11, 4) {
-            Ok(values) => {
-                assert_eq!(11, bit_vector_to_value(&values).unwrap());
-            },
-            Err(_) => {
-                panic!("Should not err")
-            },
-        }
-        match bit_vector_of_scalars(15, 4) {
-            Ok(values) => {
-                assert_eq!(15, bit_vector_to_value(&values).unwrap());
-            },
-            Err(_) => {
-                panic!("Should not err")
-            },
-        }
-        if bit_vector_of_scalars(15, 5).is_ok() {
-            panic!("Should panic");
-        }
-        if bit_vector_of_scalars(16, 4).is_ok() {
-            panic!("Should panic");
-        }
-        if bit_vector_of_scalars(0, MAX_RANGE_PROOF_BIT_LENGTH * 2).is_ok() {
-            panic!("Should panic");
-        }
-        match bit_vector_of_scalars(u64::MAX - 12187, MAX_RANGE_PROOF_BIT_LENGTH) {
-            Ok(values) => {
-                assert_eq!(u64::MAX - 12187, bit_vector_to_value(&values).unwrap());
-            },
-            Err(_) => {
-                panic!("Should not err")
-            },
-        }
-        match bit_vector_of_scalars(u64::MAX, MAX_RANGE_PROOF_BIT_LENGTH) {
-            Ok(values) => {
-                assert_eq!(u64::MAX, bit_vector_to_value(&values).unwrap());
-            },
-            Err(_) => {
-                panic!("Should not err")
-            },
-        }
+        // Valid cases
+        assert_eq!(bit_vector_to_value(&bit_vector_of_scalars(11, 4).unwrap()).unwrap(), 11);
+        assert_eq!(bit_vector_to_value(&bit_vector_of_scalars(15, 4).unwrap()).unwrap(), 15);
+        assert_eq!(
+            bit_vector_to_value(&bit_vector_of_scalars(u64::MAX - 12187, MAX_RANGE_PROOF_BIT_LENGTH).unwrap()).unwrap(),
+            u64::MAX - 12187
+        );
+        assert_eq!(
+            bit_vector_to_value(&bit_vector_of_scalars(u64::MAX, MAX_RANGE_PROOF_BIT_LENGTH).unwrap()).unwrap(),
+            u64::MAX
+        );
+
+        // Error cases
+        assert!(bit_vector_of_scalars(15, 5).is_err());
+        assert!(bit_vector_of_scalars(16, 4).is_err());
+        assert!(bit_vector_of_scalars(0, MAX_RANGE_PROOF_BIT_LENGTH * 2).is_err());
     }
 }


### PR DESCRIPTION
[Coverage](https://coveralls.io/github/tari-project/bulletproofs-plus?branch=main) for the repository is pretty good, but can be improved by adding tests.

This PR adds tests across the board.

There are a few notable changes made for more robust coverage that should receive extra attention:
- The looping strategy for `Scalar::random_not_zero` has been modified from a `loop` to a `while`. This imposes an extra constant-time equality check, but this is done directly on byte arrays and is very fast.
- The `TranscriptProtocol` trait function `append_scalar` was unused, so it has been removed entirely.
- The `RangeParameter` getter function `bp_gens` was unused, so it has been removed entirely.