### PR TITLE
fix: promise check in range statement

### DIFF
--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -42,7 +42,7 @@ impl<P: Compressable + FromUniformBytes + Clone + Precomputable> RangeStatement<
                 "Number of commitments must be a power of two".to_string(),
             ));
         }
-        if !minimum_value_promises.len() == commitments.len() {
+        if minimum_value_promises.len() != commitments.len() {
             return Err(ProofError::InvalidArgument(
                 "Incorrect number of minimum value promises".to_string(),
             ));


### PR DESCRIPTION
Range statement initialization requires the number of minimum value promises to match the number of commitments. There's currently a logic error that renders this check incorrect.

This PR fixes the logic. A test will be included in a [broader test PR](https://github.com/tari-project/bulletproofs-plus/pull/47), but the logic change is here for scope.