### PR TITLE
chore: manually clone generators

### DIFF
--- a/src/generators/bulletproof_gens.rs
+++ b/src/generators/bulletproof_gens.rs
@@ -50,9 +50,13 @@ pub struct BulletproofGens<P: Precomputable> {
     pub(crate) precomp: Arc<P::Precomputation>,
 }
 
-// This manual `Clone` implementation is required since derived cloning requires the curve library precomputation struct to support `Clone`
+// This manual `Clone` implementation is required since derived cloning requires the curve library precomputation struct
+// to support `Clone`
 impl<P> Clone for BulletproofGens<P>
-where P: Precomputable, Vec<P>: Clone {
+where
+    P: Precomputable,
+    Vec<P>: Clone,
+{
     fn clone(&self) -> Self {
         BulletproofGens {
             gens_capacity: self.gens_capacity,

--- a/src/generators/bulletproof_gens.rs
+++ b/src/generators/bulletproof_gens.rs
@@ -37,7 +37,6 @@ use crate::{
 /// This construction is also forward-compatible with constraint system proofs, which use a much larger slice of the
 /// generator chain, and even forward-compatible to multiparty aggregation of constraint system proofs, since the
 /// generators are namespaced by their party index.
-#[derive(Clone)]
 pub struct BulletproofGens<P: Precomputable> {
     /// The maximum number of usable generators for each party.
     pub gens_capacity: usize,
@@ -49,6 +48,20 @@ pub struct BulletproofGens<P: Precomputable> {
     pub(crate) h_vec: Vec<Vec<P>>,
     /// Interleaved precomputed generators
     pub(crate) precomp: Arc<P::Precomputation>,
+}
+
+// This manual `Clone` implementation is required since derived cloning requires the curve library precomputation struct to support `Clone`
+impl<P> Clone for BulletproofGens<P>
+where P: Precomputable, Vec<P>: Clone {
+    fn clone(&self) -> Self {
+        BulletproofGens {
+            gens_capacity: self.gens_capacity,
+            party_capacity: self.party_capacity,
+            g_vec: self.g_vec.clone(),
+            h_vec: self.h_vec.clone(),
+            precomp: self.precomp.clone(),
+        }
+    }
 }
 
 impl<P: FromUniformBytes + Precomputable> BulletproofGens<P> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -39,5 +39,5 @@ pub trait Decompressable {
 /// Abstraction for any type supporting multiscalar multiplication precomputation
 pub trait Precomputable {
     /// The type representing the precomputation instantiation
-    type Precomputation: Send + Sync + Clone + VartimePrecomputedMultiscalarMul<Point = Self>;
+    type Precomputation: Send + Sync + VartimePrecomputedMultiscalarMul<Point = Self>;
 }


### PR DESCRIPTION
Changes the cloning strategy for `BulletproofGens` from derived to manual. This removes the need for the curve library precomputation struct to support cloning.