### PR TITLE
feat: compute verifier challenge sum more efficiently

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ In particular, it supports:
 Compared to an [updated fork](https://github.com/tari-project/bulletproofs) of the `dalek-cryptography` [Bulletproofs](https://github.com/dalek-cryptography/bulletproofs) implementation, this Bulletproofs+ implementation is:
 - **Smaller**. Regardless of the aggregation factor, a Bulletproofs+ proof is 96 bytes shorter.
 - **Faster to generate proofs**. This implementation generates a non-aggregated 64-bit range proof about 10% faster, with similar speedups for aggregated proofs.
-- **Slower to verify single proofs**. While this implementation verifies a single 64-bit range proof in comparable time, it verifies aggregated proofs more slowly.
+- **Faster to verify single proofs**. This implementation verifies a single 64-bit range proof about 15% faster.
+- **Slower to verify aggregated proofs**. This implementaiton verifies aggregated proofs more slowly.
 - **Faster to verify batched proofs**. Because this implementation supports batching, its marginal verification time for a single 64-bit range proof can be reduced to under half the corresponding non-batched time.
 
 As always, your mileage may vary.


### PR DESCRIPTION
As part of proof verification, the verifier must compute the sum of consecutive nonzero powers of one of the Fiat-Shamir challenges. Currently, this is done naively by iteratively computing powers and adding them into an accumulator. Because the number of powers is equal to the product of the bit length and aggregation factor, this is nontrivial.

The computation can be made far more efficient. Because the sum of powers is a partial sum of a geometric series, it can be computed using [a well-known formula](https://mathworld.wolfram.com/GeometricSeries.html) (which is already used elsewhere in the verifier).

The change requires computation of an additional scalar inverse. As part of the optimization, all scalar inversions performed by the verifier are now included in a single batch operation per proof, which is more efficient.

Documentation is also updated to reflect the efficiency gain.

Overall, the result is an impressive improvement in verification. A single 64-bit range proof now verifies 7% faster.