### PR TITLE
feat!: clean up serialization

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -1007,7 +1007,10 @@ where
         }
 
         // The rest of the serialization is of 32-byte proof elements
-        let mut chunks = slice[ENCODED_EXTENSION_SIZE..].chunks_exact(SERIALIZED_ELEMENT_SIZE);
+        let mut chunks = slice
+            .get(ENCODED_EXTENSION_SIZE..)
+            .ok_or(ProofError::InvalidLength("Serialized proof is too short".to_string()))?
+            .chunks_exact(SERIALIZED_ELEMENT_SIZE);
 
         // Extract `d1`, whose length is determined by the extension degree
         let d1 = (0..extension_degree as usize)

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -87,20 +87,6 @@ pub fn bit_vector_of_scalars(value: u64, bit_length: usize) -> Result<Vec<Scalar
     Ok(result)
 }
 
-/// Given `data` with `len >= 32`, return the first 32 bytes.
-pub fn read_32_bytes(data: &[u8]) -> [u8; 32] {
-    let mut buf32 = [0u8; 32];
-    buf32[..].copy_from_slice(&data[..32]);
-    buf32
-}
-
-/// Given `data` with `len >= 1`, return the first 1 byte.
-pub fn read_1_byte(data: &[u8]) -> [u8; 1] {
-    let mut buf8 = [0u8; 1];
-    buf8[..].copy_from_slice(&data[..1]);
-    buf8
-}
-
 /// Split a vector, checking the bound to avoid a panic
 pub fn split_at_checked<T>(vec: &[T], n: usize) -> Result<(&[T], &[T]), ProofError> {
     if n <= vec.len() {


### PR DESCRIPTION
Proof serialization and deserialization currently use a custom design that optimizes space. However, the implementation relies heavily on slice indexing and is not particularly clear.

This PR updates the serialization and deserialization logic. It replaces slice indexing with chunked iteration to avoid panic conditions and improve clarity. It also modifies the serialization structure to make bounds checking more intuitive.

Closes #65.

BREAKING CHANGE: Modifies the structure of serialized proofs.