### PR TITLE
ci: update nightly toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - nightly-2022-12-10
+          - nightly-2023-06-04
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The current `nightly-2022-12-10` toolchain now breaks CI testing due to a dependency not supporting it.

This PR updates to the more recent `nightly-2023-06-04` toolchain for checks and tests.