### PR TITLE
feat!: replace `lazy_static` with `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ derive_more = "0.99"
 derivative = "2.2"
 digest = { version = "0.10", default-features = false }
 itertools = "0.6"
-lazy_static = "1.4"
 merlin = { version = "3", default-features = false }
+once_cell = { version = "1", default-features = false, features = ["critical-section"] }
 rand = "0.8"
 # Note: toolchain must be at v1.60+ to support serde v1.0.150+
 serde = "1.0"

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -42,15 +42,15 @@ pub enum ExtensionDegree {
     /// Default Pedersen commitment
     DefaultPedersen = 1,
     /// Pedersen commitment extended with one degree
-    AddOneBasePoint = 2,
+    AddOneBasePoint,
     /// Pedersen commitment extended with two degrees
-    AddTwoBasePoints = 3,
+    AddTwoBasePoints,
     /// Pedersen commitment extended with three degrees
-    AddThreeBasePoints = 4,
+    AddThreeBasePoints,
     /// Pedersen commitment extended with four degrees
-    AddFourBasePoints = 5,
+    AddFourBasePoints,
     /// Pedersen commitment extended with five degrees
-    AddFiveBasePoints = 6,
+    AddFiveBasePoints,
 }
 
 impl ExtensionDegree {

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -54,14 +54,14 @@ pub enum ExtensionDegree {
 }
 
 impl ExtensionDegree {
+    /// The total number of valid extension degrees
+    pub(crate) const COUNT: usize = ExtensionDegree::MAXIMUM - ExtensionDegree::MINIMUM + 1;
     /// The highest numerical value corresponding to a valid extension degree
     /// This MUST be correct, or other functions may panic
     pub(crate) const MAXIMUM: usize = ExtensionDegree::AddFiveBasePoints as usize;
     /// The lowest numerical value corresponding to a valid extension degree
     /// This MUST be correct, or other functions may panic
     pub(crate) const MINIMUM: usize = ExtensionDegree::DefaultPedersen as usize;
-    /// The total number of valid extension degrees
-    pub(crate) const TOTAL: usize = ExtensionDegree::MAXIMUM - ExtensionDegree::MINIMUM + 1;
 
     /// Helper function to convert a size into an extension degree
     pub fn try_from_size(size: usize) -> Result<ExtensionDegree, ProofError> {

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -36,6 +36,7 @@ pub struct PedersenGens<P: Compressable> {
 
 /// The extension degree for extended commitments. Currently this is limited to 5 extension degrees, but in theory it
 /// could be arbitrarily long, although practically, very few if any test cases will use more than 2 extension degrees.
+/// These values MUST increment, or other functions may panic.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ExtensionDegree {
     /// Default Pedersen commitment
@@ -53,9 +54,14 @@ pub enum ExtensionDegree {
 }
 
 impl ExtensionDegree {
-    /// The number of extension degrees
+    /// The highest numerical value corresponding to a valid extension degree
     /// This MUST be correct, or other functions may panic
-    pub(crate) const EXTENSION_DEGREES: usize = 6;
+    pub(crate) const MAXIMUM: usize = ExtensionDegree::AddFiveBasePoints as usize;
+    /// The lowest numerical value corresponding to a valid extension degree
+    /// This MUST be correct, or other functions may panic
+    pub(crate) const MINIMUM: usize = ExtensionDegree::DefaultPedersen as usize;
+    /// The total number of valid extension degrees
+    pub(crate) const TOTAL: usize = ExtensionDegree::MAXIMUM - ExtensionDegree::MINIMUM + 1;
 
     /// Helper function to convert a size into an extension degree
     pub fn try_from_size(size: usize) -> Result<ExtensionDegree, ProofError> {
@@ -115,11 +121,17 @@ mod test {
     use super::ExtensionDegree;
 
     #[test]
+    // Test the size range, assuming extension degree values are incremented
     fn test_extension_degree_size() {
-        // Assert the extension degree size constant is correct (remember they are 1-indexed)
-        for i in 0..ExtensionDegree::EXTENSION_DEGREES {
-            assert!(ExtensionDegree::try_from_size(i + 1).is_ok());
+        // Value is too low
+        assert!(ExtensionDegree::try_from_size(ExtensionDegree::MINIMUM - 1).is_err());
+
+        // Valid values
+        for i in ExtensionDegree::MINIMUM..=ExtensionDegree::MAXIMUM {
+            assert!(ExtensionDegree::try_from_size(i).is_ok());
         }
-        assert!(ExtensionDegree::try_from_size(ExtensionDegree::EXTENSION_DEGREES + 1).is_err());
+
+        // Value is too high
+        assert!(ExtensionDegree::try_from_size(ExtensionDegree::MAXIMUM + 1).is_err());
     }
 }

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -53,6 +53,10 @@ pub enum ExtensionDegree {
 }
 
 impl ExtensionDegree {
+    /// The number of extension degrees
+    /// This MUST be correct, or other functions may panic
+    pub(crate) const EXTENSION_DEGREES: usize = 6;
+
     /// Helper function to convert a size into an extension degree
     pub fn try_from_size(size: usize) -> Result<ExtensionDegree, ProofError> {
         match size {
@@ -103,5 +107,19 @@ where P: Compressable + MultiscalarMul<Point = P> + Clone
             let points = once(&self.h_base).chain(g_base_head);
             Ok(P::multiscalar_mul(scalars, points))
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ExtensionDegree;
+
+    #[test]
+    fn test_extension_degree_size() {
+        // Assert the extension degree size constant is correct (remember they are 1-indexed)
+        for i in 0..ExtensionDegree::EXTENSION_DEGREES {
+            assert!(ExtensionDegree::try_from_size(i + 1).is_ok());
+        }
+        assert!(ExtensionDegree::try_from_size(ExtensionDegree::EXTENSION_DEGREES + 1).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,6 @@
 
 //! Bulletproofs+
 
-#![recursion_limit = "1024"]
-
-#[macro_use]
-extern crate lazy_static;
-
 /// Bulletproofs+ commitment opening
 pub mod commitment_opening;
 /// Bulletproofs+ error definitions

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -81,14 +81,13 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
 }
 
 /// A static array of pre-generated points
-fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::EXTENSION_DEGREES] {
-    static INSTANCE: OnceCell<[RistrettoPoint; ExtensionDegree::EXTENSION_DEGREES]> = OnceCell::new();
+fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::TOTAL] {
+    static INSTANCE: OnceCell<[RistrettoPoint; ExtensionDegree::TOTAL]> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let mut arr = [RistrettoPoint::default(); ExtensionDegree::EXTENSION_DEGREES];
-        for (i, compressed) in arr.iter_mut().enumerate().take(ExtensionDegree::EXTENSION_DEGREES) {
-            // These are 1-indexed to match the `ExtensionSize` enumeration definition
-            let label = "RISTRETTO_MASKING_BASEPOINT_".to_owned() + &(i + 1).to_string();
-            *compressed = RistrettoPoint::hash_from_bytes_sha3_512(label.as_bytes());
+        let mut arr = [RistrettoPoint::default(); ExtensionDegree::TOTAL];
+        for (i, point) in (ExtensionDegree::MINIMUM..).zip(arr.iter_mut()) {
+            let label = "RISTRETTO_MASKING_BASEPOINT_".to_owned() + &i.to_string();
+            *point = RistrettoPoint::hash_from_bytes_sha3_512(label.as_bytes());
         }
 
         arr
@@ -96,10 +95,10 @@ fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::
 }
 
 /// A static array of compressed pre-generated points
-fn ristretto_compressed_masking_basepoints() -> &'static [CompressedRistretto; ExtensionDegree::EXTENSION_DEGREES] {
-    static INSTANCE: OnceCell<[CompressedRistretto; ExtensionDegree::EXTENSION_DEGREES]> = OnceCell::new();
+fn ristretto_compressed_masking_basepoints() -> &'static [CompressedRistretto; ExtensionDegree::TOTAL] {
+    static INSTANCE: OnceCell<[CompressedRistretto; ExtensionDegree::TOTAL]> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let mut arr = [CompressedRistretto::default(); ExtensionDegree::EXTENSION_DEGREES];
+        let mut arr = [CompressedRistretto::default(); ExtensionDegree::TOTAL];
         for (i, point) in ristretto_masking_basepoints().iter().enumerate() {
             arr[i] = point.compress();
         }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -81,10 +81,10 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
 }
 
 /// A static array of pre-generated points
-fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::TOTAL] {
-    static INSTANCE: OnceCell<[RistrettoPoint; ExtensionDegree::TOTAL]> = OnceCell::new();
+fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::COUNT] {
+    static INSTANCE: OnceCell<[RistrettoPoint; ExtensionDegree::COUNT]> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let mut arr = [RistrettoPoint::default(); ExtensionDegree::TOTAL];
+        let mut arr = [RistrettoPoint::default(); ExtensionDegree::COUNT];
         for (i, point) in (ExtensionDegree::MINIMUM..).zip(arr.iter_mut()) {
             let label = "RISTRETTO_MASKING_BASEPOINT_".to_owned() + &i.to_string();
             *point = RistrettoPoint::hash_from_bytes_sha3_512(label.as_bytes());
@@ -95,10 +95,10 @@ fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::
 }
 
 /// A static array of compressed pre-generated points
-fn ristretto_compressed_masking_basepoints() -> &'static [CompressedRistretto; ExtensionDegree::TOTAL] {
-    static INSTANCE: OnceCell<[CompressedRistretto; ExtensionDegree::TOTAL]> = OnceCell::new();
+fn ristretto_compressed_masking_basepoints() -> &'static [CompressedRistretto; ExtensionDegree::COUNT] {
+    static INSTANCE: OnceCell<[CompressedRistretto; ExtensionDegree::COUNT]> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let mut arr = [CompressedRistretto::default(); ExtensionDegree::TOTAL];
+        let mut arr = [CompressedRistretto::default(); ExtensionDegree::COUNT];
         for (i, point) in ristretto_masking_basepoints().iter().enumerate() {
             arr[i] = point.compress();
         }


### PR DESCRIPTION
Extended commitment generators are currently [produced](https://github.com/tari-project/bulletproofs-plus/blob/502ae9fa35a39afc5793210e4301023a7ca7ea60/src/ristretto.rs#L154-L179) using the `lazy_static` macro. Unfortunately, `lazy_static` is [no longer actively maintained](https://crates.io/crates/lazy_static). Other repositories in the ecosystem are moving to `once_cell`, which is [actively maintained](https://crates.io/crates/once_cell).

This PR migrates from `lazy_static` to `once_cell`. In the process, it cleans up the construction. Specifically, it moves from using word-based numbering (_e.g._ `ONE`, `TWO`) in hash inputs to numerals, which simplifies the design. It also adds a useful test that asserts the number of generators matches the size of `ExtensionDegree` to avoid panics.

Closes #67.

BREAKING CHANGE: Modifies the construction of commitment generators.