### PR TITLE
feat: improve zeroizing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Compared to an [updated fork](https://github.com/tari-project/bulletproofs) of t
 
 As always, your mileage may vary.
 
+This implementation uses the excellent [`zeroize`](https://crates.io/crates/zeroize) library to make a best-effort approach at minimizing exposure of value- and mask-related data in memory, as this is often considered sensitive. However, it is difficult in general to guarantee that there are no coding patterns leading to [unintended copies](https://docs.rs/zeroize/1.6.0/zeroize/#stackheap-zeroing-notes) of data, so care should always be taken not to make too many assumptions about the contents of memory.
+
 ## References
 
 This implementation takes its cue from the `dalek-cryptography` [Bulletproofs](https://github.com/dalek-cryptography/bulletproofs) implementation, as well as the Monero [Bulletproofs+](https://www.getmonero.org/2020/12/24/Bulletproofs+-in-Monero.html) implementation.

--- a/src/commitment_opening.rs
+++ b/src/commitment_opening.rs
@@ -4,12 +4,12 @@
 //! Bulletproofs+ commitment opening struct
 
 use curve25519_dalek::scalar::Scalar;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::errors::ProofError;
 
 /// Commitment openings to be used for Pedersen commitments
-#[derive(Clone, Zeroize)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct CommitmentOpening {
     /// Value
     pub(crate) v: u64,
@@ -32,14 +32,6 @@ impl CommitmentOpening {
         } else {
             Ok(self.r.len())
         }
-    }
-}
-
-/// Overwrite secrets with null bytes when they go out of scope.
-impl Drop for CommitmentOpening {
-    fn drop(&mut self) {
-        self.v.zeroize();
-        self.r.zeroize();
     }
 }
 

--- a/src/extended_mask.rs
+++ b/src/extended_mask.rs
@@ -4,11 +4,12 @@
 //! Bulletproofs+ embedded extended mask
 
 use curve25519_dalek::scalar::Scalar;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{errors::ProofError, generators::pedersen_gens::ExtensionDegree};
 
 /// Contains the embedded extended mask for non-aggregated proofs
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Zeroize, ZeroizeOnDrop)]
 pub struct ExtendedMask {
     blindings: Vec<Scalar>, // Do not allow direct assignment of struct member (i.e. should not be public)
 }

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -7,6 +7,7 @@
 use std::{borrow::Borrow, convert::TryFrom, iter::once};
 
 use curve25519_dalek::{scalar::Scalar, traits::MultiscalarMul};
+use zeroize::Zeroize;
 
 use crate::{errors::ProofError, traits::Compressable};
 
@@ -37,7 +38,7 @@ pub struct PedersenGens<P: Compressable> {
 /// The extension degree for extended commitments. Currently this is limited to 5 extension degrees, but in theory it
 /// could be arbitrarily long, although practically, very few if any test cases will use more than 2 extension degrees.
 /// These values MUST increment, or other functions may panic.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Zeroize)]
 pub enum ExtensionDegree {
     /// Default Pedersen commitment
     DefaultPedersen = 1,

--- a/src/range_witness.rs
+++ b/src/range_witness.rs
@@ -5,12 +5,12 @@
 
 use std::convert::TryInto;
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{commitment_opening::CommitmentOpening, errors::ProofError, generators::pedersen_gens::ExtensionDegree};
 
 /// A convenience struct for holding commitment openings for the aggregated case
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct RangeWitness {
     /// The vector of commitment openings for the aggregated case
     pub openings: Vec<CommitmentOpening>,
@@ -36,15 +36,6 @@ impl RangeWitness {
             openings,
             extension_degree: extension_degree.try_into()?,
         })
-    }
-}
-
-/// Overwrite secrets with null bytes when they go out of scope.
-impl Drop for RangeWitness {
-    fn drop(&mut self) {
-        for item in &mut self.openings {
-            item.zeroize();
-        }
     }
 }
 

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -17,6 +17,7 @@ use std::convert::TryFrom;
 
 use blake2::Blake2bMac512;
 use curve25519_dalek::scalar::Scalar;
+use zeroize::Zeroizing;
 
 use crate::{errors::ProofError, protocols::scalar_protocol::ScalarProtocol, range_proof::MAX_RANGE_PROOF_BIT_LENGTH};
 
@@ -47,7 +48,7 @@ pub fn nonce(
 
     // We use fixed-length encodings of the seed and (optional) indexes
     // Further, we use domain separation for the indexes to avoid collisions
-    let mut key = Vec::with_capacity(43); // 1 + 32 + optional(1 + 4)  + optional(1 + 4)
+    let mut key = Zeroizing::new(Vec::with_capacity(43)); // 1 + 32 + optional(1 + 4)  + optional(1 + 4)
     key.push(0u8); // Initialize the vector to enable 'append' (1 byte)
     key.append(&mut seed_nonce.to_bytes().to_vec()); // Fixed length encoding of 'seed_nonce' (32 bytes)
     if let Some(index) = index_j {


### PR DESCRIPTION
Adds zeroizing and zeroing on drop to `ExtendedMask`. Moves from manual zeroizing-on-drop to the derived `ZeroizeOnDrop` trait for `CommitmentOpening` and `RangeWitness`.

Updates the prover algorithm to zeroize value- and mask-related data, including nonces.

Updates the documentation with a brief note about zeroizing support and caveats.

Closes #71.