### PR TITLE
ci: don't build dependency documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
+          args: --no-deps


### PR DESCRIPTION
Currently, CI builds documentation for all dependencies, which seems unnecessary.

Fortunately, there's a [flag](https://doc.rust-lang.org/cargo/commands/cargo-doc.html#documentation-options) to disable this behavior. This PR adds the flag to make CI a bit speedier.