### PR TITLE
ci: update CI actions

### DIFF
--- a/.github/workflows/check_licence.yml
+++ b/.github/workflows/check_licence.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: install ripgrep
         run: |
           wget https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb

--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,26 +1,25 @@
 on: [pull_request]
 name: Clippy
 jobs:
-  clippy_check:
+  format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          components: clippy, rustfmt
+          components: rustfmt
           toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
+      - name: Formatting
+        run: cargo +nightly fmt --all -- --check
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          command: fmt
-          args: --all -- --check
-      - name: Install cargo-lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-lints
-      - name: Clippy lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: lints
-          args: clippy --all-targets
+          components: clippy
+          toolchain: stable
+      - name: Install linter
+        run: cargo install cargo-lints
+      - name: Lints
+        run: cargo +stable lints clippy --all-targets

--- a/.github/workflows/source-cov.yml
+++ b/.github/workflows/source-cov.yml
@@ -10,16 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install -y jq lcov
       - name: Download Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
           components: llvm-tools-preview
       - name: Install requirements for code coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,29 +13,16 @@ jobs:
           - nightly-2023-06-04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all-targets
+        run: cargo +${{ matrix.rust }} check --all-features --all-targets
       - name: test/debug
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo +${{ matrix.rust }} test --all-features
       - name: test/release
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features
-      - name: docs build
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
+        run: cargo +${{ matrix.rust }} test --release --all-features
+      - name: Build documentation
+        run: cargo +${{ matrix.rust }} doc --no-deps


### PR DESCRIPTION
Unfortunately, the popular `actions-rs` project, which supported Rust CI, has been [unmaintained](https://github.com/actions-rs/toolchain/issues/216) for some time. In addition, the default repository `checkout` action has been [updated](https://github.com/actions/checkout/releases/tag/v4.0.0). Finally, documentation builds include dependencies, which slows down testing unnecessarily.

This PR addresses all of these issues.

First, it migrates from `actions-rs` to the [maintained](https://github.com/dtolnay/rust-toolchain) `dtolnay/rust-toolchain` action. Further, it updates the `checkout` action. Finally, it passes a [flag](https://doc.rust-lang.org/cargo/commands/cargo-doc.html#documentation-options) that ignores dependencies when building documentation. The result is a more modern and streamlined CI flow.

This supersedes #74.