### PR TITLE
ci: deserialization fuzz testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand_core = "0.6"
 [dev-dependencies]
 bincode = "1"
 criterion = "0.5"
+quickcheck = "1"
 
 [[bench]]
 name = "range_proof"

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -1066,6 +1066,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+    use quickcheck::QuickCheck;
 
     use super::*;
     use crate::{
@@ -1075,6 +1076,26 @@ mod tests {
         ristretto::{create_pedersen_gens_with_extension_degree, RistrettoRangeProof},
         BulletproofGens,
     };
+
+    #[test]
+    #[allow(clippy::needless_pass_by_value)]
+    fn test_deserialization() {
+        fn internal(bytes: Vec<u8>) -> bool {
+            // Deserialization should either fail or serialize canonically
+            match RistrettoRangeProof::from_bytes(&bytes) {
+                Err(_) => true,
+                Ok(proof) => proof.to_bytes() == bytes,
+            }
+        }
+
+        const TESTS: u64 = 100_000;
+
+        QuickCheck::new()
+            .min_tests_passed(TESTS)
+            .tests(TESTS)
+            .max_tests(TESTS)
+            .quickcheck(internal as fn(Vec<u8>) -> bool);
+    }
 
     #[test]
     fn test_from_bytes() {


### PR DESCRIPTION
This adds basic deserialization fuzz testing to CI via [`quickcheck`](https://github.com/BurntSushi/quickcheck). Because it uses a limited number of randomized test runs, it is not particularly thorough, and should not be considered a replacement for the fuzz testing added in #79. That being said, it's a reasonable sanity check and runs quickly.

Closes #80.