### PR TITLE
chore!: clean up `ExtensionDegree`

### DIFF
--- a/src/extended_mask.rs
+++ b/src/extended_mask.rs
@@ -40,6 +40,8 @@ impl ExtendedMask {
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryFrom;
+
     use super::*;
 
     #[test]
@@ -47,7 +49,7 @@ mod test {
         // Valid assignments
         for degree in 1..=6 {
             let blindings = vec![Scalar::ZERO; degree];
-            let extension = ExtensionDegree::try_from_size(degree).unwrap();
+            let extension = ExtensionDegree::try_from(degree).unwrap();
 
             assert!(ExtendedMask::assign(extension, blindings).is_ok());
         }

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -545,7 +545,7 @@ where
         let mut max_index = 0;
         let extension_degree = first_statement.generators.extension_degree();
 
-        if extension_degree != ExtensionDegree::try_from_size(first_proof.d1.len())? {
+        if extension_degree != ExtensionDegree::try_from(first_proof.d1.len())? {
             return Err(ProofError::InvalidArgument("Inconsistent extension degree".to_string()));
         }
         for (i, (statement, proof)) in statements.iter().zip(range_proofs.iter()).enumerate().skip(1) {
@@ -565,7 +565,7 @@ where
                 ));
             }
             if extension_degree != statement.generators.extension_degree() ||
-                extension_degree != ExtensionDegree::try_from_size(proof.d1.len())?
+                extension_degree != ExtensionDegree::try_from(proof.d1.len())?
             {
                 return Err(ProofError::InvalidArgument("Inconsistent extension degree".to_string()));
             }
@@ -1034,8 +1034,7 @@ where
         let extension_degree = ExtensionDegree::try_from(
             *(slice
                 .first()
-                .ok_or_else(|| ProofError::InvalidLength("Serialized proof is too short".to_string()))?)
-                as usize,
+                .ok_or_else(|| ProofError::InvalidLength("Serialized proof is too short".to_string()))?),
         )?;
 
         // Now ensure the proof is long enough to account for all required elements:
@@ -1318,7 +1317,7 @@ mod tests {
         let mut proof_bytes_meddled = proof_bytes.clone();
 
         for i in 0..u8::MAX {
-            if ExtensionDegree::try_from(i as usize).is_err() {
+            if ExtensionDegree::try_from(i).is_err() {
                 proof_bytes_meddled[0] = i;
                 assert!(RistrettoRangeProof::from_bytes(&proof_bytes_meddled).is_err());
                 break;


### PR DESCRIPTION
Currently, `ExtensionDegree` discriminants are represented as `isize` by the compiler. The enumeration implements `TryFrom<usize>` via a wrapper to a public function `ExtensionDegreee::try_from_size` that is used in the library. This is inelegant, makes deserialization (which acts on bytes) more awkward, and introduces the possibility that a future enumeration update could overflow `u8` and cause serialization problems.

This PR moves the functionality of `ExtensionDegree::try_from_size` into a `TryFrom<u8>` implementation, and implements `TryFrom<usize>` as a wrapper. It changes the discriminant representation to `u8`, which will ensure that any future change to `ExtensionDegree` that could overflow will be caught by the compiler.

BREAKING CHANGE: Introduces a change to the `ExtensionDegree` public API.