### PR TITLE
chore!: unused method cleanup

### DIFF
--- a/src/range_parameters.rs
+++ b/src/range_parameters.rs
@@ -100,19 +100,9 @@ where P: FromUniformBytes + Compressable + Clone + Precomputable
         self.bp_gens.h_iter(self.bit_length(), self.aggregation_factor())
     }
 
-    /// Return the non-public value bulletproof generator references
-    pub fn hi_base_ref(&self) -> Vec<&P> {
-        self.hi_base_iter().collect()
-    }
-
     /// Return the non-public mask iterator to the bulletproof generators
     pub fn gi_base_iter(&self) -> impl Iterator<Item = &P> {
         self.bp_gens.g_iter(self.bit_length(), self.aggregation_factor())
-    }
-
-    /// Return the non-public mask bulletproof generator references
-    pub fn gi_base_ref(&self) -> Vec<&P> {
-        self.gi_base_iter().collect()
     }
 
     /// Return the interleaved precomputation tables


### PR DESCRIPTION
Removes public methods that became unused after #87 was merged.

BREAKING CHANGE: Removes unused methods that were public, which is technically a breaking change.