### PR TITLE
ci: update nightly and fail on doc warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: test/release
         run: cargo +${{ matrix.rust }} test --release --all-features
       - name: Build documentation
-        run: cargo +${{ matrix.rust }} doc --no-deps
+        run: RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.rust }} doc --no-deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - nightly-2023-06-04
+          - nightly
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/src/protocols/scalar_protocol.rs
+++ b/src/protocols/scalar_protocol.rs
@@ -13,7 +13,7 @@ pub trait ScalarProtocol {
     /// Returns a non-zero random Scalar
     fn random_not_zero<R: RngCore + CryptoRng>(rng: &mut R) -> Scalar;
 
-    /// Construct a scalar from an existing Blake2b instance (helper function to implement 'Scalar::from_hash<Blake2b>')
+    /// Construct a scalar from an existing Blake2b instance (helper function to implement `Scalar::from_hash<Blake2b>`)
     fn from_hasher_blake2b(hasher: Blake2bMac512) -> Scalar;
 }
 


### PR DESCRIPTION
Currently, CI testing uses a fixed nightly toolchain. While this is useful against a spurious nightly build, the repository already uses the latest nightly for formatting, lints, and checks. I think it's worth it to stick with the latest nightly across the board.

Additionally, this updates documentation checks to fail on warnings. This ensures that the documentation warnings don't go unnoticed.