### PR TITLE
feat: support `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package = "tari-curve25519-dalek", version = "4.0.3", features = ["serde", "rand_core"] }
+curve25519-dalek = { package = "tari-curve25519-dalek", version = "4.0.3", default-features = false, features = ["alloc", "serde", "rand_core", "zeroize"] }
 digest = { version = "0.10", default-features = false }
 itertools = { version = "0.12", default-features = false, features = ["use_alloc"] }
 merlin = { version = "3", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["critical-section"] }
 rand = { version = "0.8", optional = true }
-serde = { version = "1.0", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["alloc"] }
 sha3 = { version = "0.10", default-features = false }
 thiserror-no-std = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/src/commitment_opening.rs
+++ b/src/commitment_opening.rs
@@ -3,6 +3,8 @@
 
 //! Bulletproofs+ commitment opening struct
 
+use alloc::vec::Vec;
+
 use curve25519_dalek::scalar::Scalar;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 

--- a/src/extended_mask.rs
+++ b/src/extended_mask.rs
@@ -3,6 +3,8 @@
 
 //! Bulletproofs+ embedded extended mask
 
+use alloc::vec::Vec;
+
 use curve25519_dalek::scalar::Scalar;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -40,7 +42,7 @@ impl ExtendedMask {
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     use super::*;
 

--- a/src/generators/aggregated_gens_iter.rs
+++ b/src/generators/aggregated_gens_iter.rs
@@ -4,6 +4,8 @@
 //     Copyright (c) 2018 Chain, Inc.
 //     SPDX-License-Identifier: MIT
 
+use alloc::vec::Vec;
+
 /// A convenience iterator struct for the generators
 pub struct AggregatedGensIter<'a, P> {
     pub(super) array: &'a Vec<Vec<P>>,

--- a/src/generators/bulletproof_gens.rs
+++ b/src/generators/bulletproof_gens.rs
@@ -4,10 +4,10 @@
 //     Copyright (c) 2018 Chain, Inc.
 //     SPDX-License-Identifier: MIT
 
-use std::{
+use alloc::{sync::Arc, vec::Vec};
+use core::{
     convert::TryFrom,
     fmt::{Debug, Formatter},
-    sync::Arc,
 };
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -139,7 +139,7 @@ where
     P: Compressable + Debug + Precomputable,
     P::Compressed: Debug,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("RangeParameters")
             .field("gens_capacity", &self.gens_capacity)
             .field("party_capacity", &self.party_capacity)

--- a/src/generators/generators_chain.rs
+++ b/src/generators/generators_chain.rs
@@ -4,7 +4,7 @@
 //     Copyright (c) 2018 Chain, Inc.
 //     SPDX-License-Identifier: MIT
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use digest::{core_api::XofReaderCoreWrapper, ExtendableOutput, Update, XofReader};
 use sha3::{Shake256, Shake256ReaderCore};

--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -4,7 +4,8 @@
 //     Copyright (c) 2018 Chain, Inc.
 //     SPDX-License-Identifier: MIT
 
-use std::{borrow::Borrow, convert::TryFrom, iter::once};
+use alloc::vec::Vec;
+use core::{borrow::Borrow, convert::TryFrom, iter::once};
 
 use curve25519_dalek::{scalar::Scalar, traits::MultiscalarMul};
 use zeroize::Zeroize;
@@ -124,7 +125,7 @@ where P: Compressable + MultiscalarMul<Point = P> + Clone
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     use super::ExtensionDegree;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,6 @@ pub use generators::bulletproof_gens::BulletproofGens;
 pub use generators::pedersen_gens::PedersenGens;
 
 pub mod ristretto;
+
+#[macro_use]
+extern crate alloc;

--- a/src/protocols/curve_point_protocol.rs
+++ b/src/protocols/curve_point_protocol.rs
@@ -3,7 +3,7 @@
 
 //! Bulletproofs+ `CurvePointProtocol` trait provides the required interface for curves using BP+.
 
-use std::{
+use core::{
     borrow::Borrow,
     ops::{Add, AddAssign},
 };

--- a/src/range_parameters.rs
+++ b/src/range_parameters.rs
@@ -3,10 +3,8 @@
 
 //! Bulletproofs+ range parameters (generators and base points) needed for a batch of range proofs
 
-use std::{
-    fmt::{Debug, Formatter},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+use core::fmt::{Debug, Formatter};
 
 use crate::{
     errors::ProofError,
@@ -116,7 +114,7 @@ where
     P: Compressable + Debug + Precomputable,
     P::Compressed: Debug,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("RangeParameters")
             .field("pc_gens", &self.pc_gens)
             .field("bp_gens", &self.bp_gens)

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -5,8 +5,10 @@
 
 #![allow(clippy::too_many_lines)]
 
-use std::{
+use alloc::vec::Vec;
+use core::{
     convert::{TryFrom, TryInto},
+    iter::once,
     marker::PhantomData,
     ops::{Add, Mul, Shr},
     slice::ChunksExact,
@@ -440,24 +442,18 @@ where
 
             // Compute L and R by multi-scalar multiplication
             li.push(P::vartime_multiscalar_mul(
-                std::iter::once::<&Scalar>(&c_l)
+                once::<&Scalar>(&c_l)
                     .chain(d_l.iter())
                     .chain(a_lo_offset.iter())
                     .chain(b_hi.iter()),
-                std::iter::once(h_base)
-                    .chain(g_base.iter())
-                    .chain(gi_base_hi)
-                    .chain(hi_base_lo),
+                once(h_base).chain(g_base.iter()).chain(gi_base_hi).chain(hi_base_lo),
             ));
             ri.push(P::vartime_multiscalar_mul(
-                std::iter::once::<&Scalar>(&c_r)
+                once::<&Scalar>(&c_r)
                     .chain(d_r.iter())
                     .chain(a_hi_offset.iter())
                     .chain(b_lo.iter()),
-                std::iter::once(h_base)
-                    .chain(g_base.iter())
-                    .chain(gi_base_lo)
-                    .chain(hi_base_hi),
+                once(h_base).chain(g_base.iter()).chain(gi_base_lo).chain(hi_base_hi),
             ));
 
             // Get the round challenge and associated values
@@ -1242,7 +1238,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
     use quickcheck::QuickCheck;

--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -4,6 +4,8 @@
 //! Bulletproofs+ generators, vector of commitments, vector of optional minimum promised
 //! values and a vector of optional seed nonces for mask recovery
 
+use alloc::vec::Vec;
+
 use curve25519_dalek::scalar::Scalar;
 use zeroize::Zeroize;
 

--- a/src/range_witness.rs
+++ b/src/range_witness.rs
@@ -3,7 +3,7 @@
 
 //! Bulletproofs+ commitment openings for the aggregated case
 
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -5,6 +5,8 @@
 //!
 //! Implementation of BulletProofs for the Ristretto group for Curve25519.
 
+use alloc::vec::Vec;
+
 use curve25519_dalek::{
     constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
     ristretto::{CompressedRistretto, RistrettoPoint, VartimeRistrettoPrecomputation},

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -7,13 +7,13 @@
 //! Bulletproofs+ utilities
 
 use core::{
+    convert::TryFrom,
     option::{Option, Option::Some},
     result::{
         Result,
         Result::{Err, Ok},
     },
 };
-use std::convert::TryFrom;
 
 use blake2::Blake2bMac512;
 use curve25519_dalek::scalar::Scalar;


### PR DESCRIPTION
It may be useful for this library to play nicely with `no_std` targets, despite its rather heavy memory requirements. This PR ensures that the library is `no_std` compatible out of the box, without needing to fiddle with features.

Closes #102.