### PR TITLE
feat: use `TranscriptRng` for random number generation

### DIFF
--- a/src/range_witness.rs
+++ b/src/range_witness.rs
@@ -5,7 +5,7 @@
 
 use std::convert::TryInto;
 
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::{commitment_opening::CommitmentOpening, errors::ProofError, generators::pedersen_gens::ExtensionDegree};
 
@@ -36,6 +36,21 @@ impl RangeWitness {
             openings,
             extension_degree: extension_degree.try_into()?,
         })
+    }
+
+    /// Produce a byte representation of the witness data for use in transcript RNG seeding
+    /// Note that this does _not_ need to be canonical!
+    pub(crate) fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
+        let mut bytes = Zeroizing::new(Vec::<u8>::new());
+
+        for opening in &self.openings {
+            bytes.extend(opening.v.to_le_bytes());
+            for r in &opening.r {
+                bytes.extend(r.as_bytes());
+            }
+        }
+
+        bytes
     }
 }
 

--- a/src/range_witness.rs
+++ b/src/range_witness.rs
@@ -5,7 +5,7 @@
 
 use std::convert::TryInto;
 
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{commitment_opening::CommitmentOpening, errors::ProofError, generators::pedersen_gens::ExtensionDegree};
 
@@ -36,21 +36,6 @@ impl RangeWitness {
             openings,
             extension_degree: extension_degree.try_into()?,
         })
-    }
-
-    /// Produce a byte representation of the witness data for use in transcript RNG seeding
-    /// Note that this does _not_ need to be canonical!
-    pub(crate) fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
-        let mut bytes = Zeroizing::new(Vec::<u8>::new());
-
-        for opening in &self.openings {
-            bytes.extend(opening.v.to_le_bytes());
-            for r in &opening.r {
-                bytes.extend(r.as_bytes());
-            }
-        }
-
-        bytes
     }
 }
 

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -2,7 +2,8 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 
 use curve25519_dalek::{scalar::Scalar, traits::IsIdentity};
-use merlin::Transcript;
+use merlin::{Transcript, TranscriptRng};
+use rand_core::CryptoRngCore;
 
 use crate::{
     errors::ProofError,
@@ -73,4 +74,16 @@ pub(crate) fn transcript_points_a1_b_challenge_e<P: FixedBytesRepr + IsIdentity>
     transcript.validate_and_append_point(b"A1", a1)?;
     transcript.validate_and_append_point(b"B", b)?;
     transcript.challenge_scalar(b"e")
+}
+
+/// Helper function to get a random number generator from a transcript
+pub(crate) fn transcript_make_rng<R: CryptoRngCore>(
+    transcript: &mut Transcript,
+    witness_bytes: &[u8],
+    rng: &mut R,
+) -> TranscriptRng {
+    transcript
+        .build_rng()
+        .rekey_with_witness_bytes("witness".as_bytes(), witness_bytes)
+        .finalize(rng)
 }

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -1,89 +1,116 @@
 //  Copyright 2022 The Tari Project
 //  SPDX-License-Identifier: BSD-3-Clause
 
+use core::mem::size_of;
+use std::marker::PhantomData;
+
 use curve25519_dalek::{scalar::Scalar, traits::IsIdentity};
 use merlin::{Transcript, TranscriptRng};
 use rand_core::CryptoRngCore;
+use zeroize::Zeroizing;
 
 use crate::{
     errors::ProofError,
     protocols::transcript_protocol::TranscriptProtocol,
     range_statement::RangeStatement,
+    range_witness::RangeWitness,
     traits::{Compressable, FixedBytesRepr, Precomputable},
 };
 
-// Helper function to construct the initial transcript
-pub(crate) fn transcript_initialize<P>(
-    transcript: &mut Transcript,
-    h_base_compressed: &P::Compressed,
-    g_base_compressed: &[P::Compressed],
-    bit_length: usize,
-    extension_degree: usize,
-    aggregation_factor: usize,
-    statement: &RangeStatement<P>,
-) -> Result<(), ProofError>
+/// A wrapper around a Merlin transcript
+pub(crate) struct RangeProofTranscript<P>
 where
     P: Compressable + Precomputable,
     P::Compressed: FixedBytesRepr + IsIdentity,
 {
-    transcript.validate_and_append_point(b"H", h_base_compressed)?;
-    for item in g_base_compressed {
-        transcript.validate_and_append_point(b"G", item)?;
-    }
-    transcript.append_u64(b"N", bit_length as u64);
-    transcript.append_u64(b"T", extension_degree as u64);
-    transcript.append_u64(b"M", aggregation_factor as u64);
-    for item in &statement.commitments_compressed {
-        transcript.append_point(b"Ci", item);
-    }
-    for item in &statement.minimum_value_promises {
-        if let Some(minimum_value) = item {
-            transcript.append_u64(b"vi - minimum_value", *minimum_value);
-        } else {
-            transcript.append_u64(b"vi - minimum_value", 0);
+    transcript: Transcript,
+    _phantom: PhantomData<P>,
+}
+
+impl<P> RangeProofTranscript<P>
+where
+    P: Compressable + Precomputable,
+    P::Compressed: FixedBytesRepr + IsIdentity,
+{
+    // Initialize a transcript
+    pub(crate) fn new(
+        label: &'static str,
+        h_base_compressed: &P::Compressed,
+        g_base_compressed: &[P::Compressed],
+        bit_length: usize,
+        extension_degree: usize,
+        aggregation_factor: usize,
+        statement: &RangeStatement<P>,
+    ) -> Result<Self, ProofError> {
+        // Initialize the transcript with parameters and statement
+        let mut transcript = Transcript::new(label.as_bytes());
+        transcript.domain_separator(b"Bulletproofs+", b"Range Proof");
+        transcript.validate_and_append_point(b"H", h_base_compressed)?;
+        for item in g_base_compressed {
+            transcript.validate_and_append_point(b"G", item)?;
         }
+        transcript.append_u64(b"N", bit_length as u64);
+        transcript.append_u64(b"T", extension_degree as u64);
+        transcript.append_u64(b"M", aggregation_factor as u64);
+        for item in &statement.commitments_compressed {
+            transcript.append_point(b"Ci", item);
+        }
+        for item in &statement.minimum_value_promises {
+            if let Some(minimum_value) = item {
+                transcript.append_u64(b"vi - minimum_value", *minimum_value);
+            } else {
+                transcript.append_u64(b"vi - minimum_value", 0);
+            }
+        }
+
+        Ok(Self {
+            transcript,
+            _phantom: PhantomData,
+        })
     }
-    Ok(())
-}
-// Helper function to construct the y and z challenge scalars after points A
-pub(crate) fn transcript_point_a_challenges_y_z<P: FixedBytesRepr + IsIdentity>(
-    transcript: &mut Transcript,
-    a: &P,
-) -> Result<(Scalar, Scalar), ProofError> {
-    transcript.validate_and_append_point(b"A", a)?;
-    Ok((transcript.challenge_scalar(b"y")?, transcript.challenge_scalar(b"z")?))
-}
 
-/// Helper function to construct the e challenge scalar after points L and R
-pub(crate) fn transcript_points_l_r_challenge_e<P: FixedBytesRepr + IsIdentity>(
-    transcript: &mut Transcript,
-    l: &P,
-    r: &P,
-) -> Result<Scalar, ProofError> {
-    transcript.validate_and_append_point(b"L", l)?;
-    transcript.validate_and_append_point(b"R", r)?;
-    transcript.challenge_scalar(b"e")
-}
+    // Construct the `y` and `z` challenges
+    pub(crate) fn challenges_y_z(&mut self, a: &P::Compressed) -> Result<(Scalar, Scalar), ProofError> {
+        self.transcript.validate_and_append_point(b"A", a)?;
+        Ok((
+            self.transcript.challenge_scalar(b"y")?,
+            self.transcript.challenge_scalar(b"z")?,
+        ))
+    }
 
-/// Helper function to construct the e challenge scalar after points A1 and B
-pub(crate) fn transcript_points_a1_b_challenge_e<P: FixedBytesRepr + IsIdentity>(
-    transcript: &mut Transcript,
-    a1: &P,
-    b: &P,
-) -> Result<Scalar, ProofError> {
-    transcript.validate_and_append_point(b"A1", a1)?;
-    transcript.validate_and_append_point(b"B", b)?;
-    transcript.challenge_scalar(b"e")
-}
+    /// Construct an inner-product round `e` challenge
+    pub(crate) fn challenge_round_e(&mut self, l: &P::Compressed, r: &P::Compressed) -> Result<Scalar, ProofError> {
+        self.transcript.validate_and_append_point(b"L", l)?;
+        self.transcript.validate_and_append_point(b"R", r)?;
+        self.transcript.challenge_scalar(b"e")
+    }
 
-/// Helper function to get a random number generator from a transcript
-pub(crate) fn transcript_make_rng<R: CryptoRngCore>(
-    transcript: &mut Transcript,
-    witness_bytes: &[u8],
-    rng: &mut R,
-) -> TranscriptRng {
-    transcript
-        .build_rng()
-        .rekey_with_witness_bytes("witness".as_bytes(), witness_bytes)
-        .finalize(rng)
+    /// Construct the final `e` challenge
+    pub(crate) fn challenge_final_e(&mut self, a1: &P::Compressed, b: &P::Compressed) -> Result<Scalar, ProofError> {
+        self.transcript.validate_and_append_point(b"A1", a1)?;
+        self.transcript.validate_and_append_point(b"B", b)?;
+        self.transcript.challenge_scalar(b"e")
+    }
+
+    /// Construct a random number generator from the current transcript state
+    pub(crate) fn build_rng<R: CryptoRngCore>(&self, witness: &RangeWitness, rng: &mut R) -> TranscriptRng {
+        // Produce a (non-canonical) byte representation of the witness
+        let size: usize = witness
+            .openings
+            .iter()
+            .map(|o| size_of::<u64>() + o.r.len() * size_of::<Scalar>())
+            .sum();
+        let mut witness_bytes = Zeroizing::new(Vec::<u8>::with_capacity(size));
+        for opening in &witness.openings {
+            witness_bytes.extend(opening.v.to_le_bytes());
+            for r in &opening.r {
+                witness_bytes.extend(r.as_bytes());
+            }
+        }
+
+        self.transcript
+            .build_rng()
+            .rekey_with_witness_bytes("witness".as_bytes(), &witness_bytes)
+            .finalize(rng)
+    }
 }


### PR DESCRIPTION
As noted in #108, it's possible to improve the robustness of prover nonces by using Merlin's `TranscriptRng` functionality.

This PR moves all prover nonce generation to this design. In particular, it ensures that the most up-to-date state of the transcript is used each time the prover needs secure randomness (per the Merlin [documentation](https://docs.rs/merlin/latest/merlin/struct.TranscriptRngBuilder.html#note)). The verifier also uses this to produce its random weights.

It also takes the opportunity to refactor transcript operations so they are cleaner and likely safer to use.

Closes #108.