### PR TITLE
feat: move RNGs into `RangeProofTranscript`

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -278,7 +278,7 @@ where
         }
 
         // Start a new transcript and generate the transcript RNG
-        let mut transcript = RangeProofTranscript::<P>::new(
+        let mut transcript = RangeProofTranscript::<P, R>::new(
             transcript_label,
             &statement.generators.h_base().compress(),
             statement.generators.g_bases_compressed(),
@@ -332,7 +332,7 @@ where
         );
 
         // Update transcript, get challenges, and update RNG
-        let (y, z) = transcript.challenges_y_z(rng, &a.compress())?;
+        let (y, z) = transcript.challenges_y_z(&a.compress())?;
 
         let z_square = z * z;
 
@@ -466,7 +466,6 @@ where
 
             // Update transcript, get challenge, and update RNG
             let e = transcript.challenge_round_e(
-                rng,
                 &li.last()
                     .ok_or(ProofError::InvalidLength("Bad inner product vector length".to_string()))?
                     .compress(),
@@ -552,7 +551,7 @@ where
         }
 
         // Update transcript, get challenge, and update RNG
-        let e = transcript.challenge_final_e(rng, &a1.compress(), &b.compress())?;
+        let e = transcript.challenge_final_e(&a1.compress(), &b.compress())?;
         let e_square = e * e;
 
         let r1 = *r + a_li[0] * e;
@@ -837,14 +836,14 @@ where
             )?;
 
             // Reconstruct challenges
-            let (y, z) = transcript.challenges_y_z(rng, &proof.a)?;
+            let (y, z) = transcript.challenges_y_z(&proof.a)?;
             let challenges = proof
                 .li
                 .iter()
                 .zip(proof.ri.iter())
-                .map(|(l, r)| transcript.challenge_round_e(rng, l, r))
+                .map(|(l, r)| transcript.challenge_round_e(l, r))
                 .collect::<Result<Vec<Scalar>, ProofError>>()?;
-            let e = transcript.challenge_final_e(rng, &proof.a1, &proof.b)?;
+            let e = transcript.challenge_final_e(&proof.a1, &proof.b)?;
 
             // Batch weight (may not be equal to a zero valued scalar) - this may not be zero ever
             let weight = Scalar::random_not_zero(transcript.as_mut_rng());

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -28,12 +28,9 @@ use crate::{
 ///
 /// When the prover initializes the wrapper, it includes the witness as the secret data.
 /// The verifier doesn't have any secret data to include, so it passes `None` instead.
-/// In either case, you get a `RangeProofTranscript` and a `TranscriptRng`.
+/// In either case, you get a `RangeProofTranscript` that is updated when you use the challenge functions.
 ///
-/// When the transcript is updated using the challenge functions, you must provide the `TranscriptRng`, which is also
-/// updated.
-///
-/// When randomness is needed, just use the `TranscriptRng`.
+/// When you need randomness, use `as_mut_rng()` to get an `&mut TranscriptRng` for this purpose.
 /// The prover uses this whenever it needs a random nonce.
 /// The batch verifier uses this to generate weights.
 pub(crate) struct RangeProofTranscript<'a, P, R>

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -44,7 +44,7 @@ where
 {
     transcript: Transcript,
     bytes: Option<Zeroizing<Vec<u8>>>,
-    rng: TranscriptRng,
+    transcript_rng: TranscriptRng,
     external_rng: &'a mut R,
     _phantom: PhantomData<P>,
 }
@@ -117,7 +117,7 @@ where
         Ok(Self {
             transcript,
             bytes,
-            rng,
+            transcript_rng: rng,
             external_rng,
             _phantom: PhantomData,
         })
@@ -129,7 +129,7 @@ where
         self.transcript.validate_and_append_point(b"A", a)?;
 
         // Update the RNG
-        self.rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
+        self.transcript_rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
 
         // Return the challenges
         Ok((
@@ -145,7 +145,7 @@ where
         self.transcript.validate_and_append_point(b"R", r)?;
 
         // Update the RNG
-        self.rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
+        self.transcript_rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
 
         // Return the challenge
         self.transcript.challenge_scalar(b"e")
@@ -158,7 +158,7 @@ where
         self.transcript.validate_and_append_point(b"B", b)?;
 
         // Update the RNG
-        self.rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
+        self.transcript_rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
 
         // Return the challenge
         self.transcript.challenge_scalar(b"e")
@@ -182,6 +182,6 @@ where
     /// Get a mutable reference to the transcript RNG.
     /// This is suitable for passing into functions that use it to generate random data.
     pub(crate) fn as_mut_rng(&mut self) -> &mut TranscriptRng {
-        &mut self.rng
+        &mut self.transcript_rng
     }
 }


### PR DESCRIPTION
Recent work in #109 uses Merlin's `TranscriptRng` functionality to improve handling of random number generation, and also refactors transcript operations for safer use through a `RangeProofTranscript` wrapper.

A [suggestion](https://github.com/tari-project/bulletproofs-plus/pull/109#discussion_r1449861417) by @sdbondi recommends moving the `TranscriptRng` into `RangeProofTranscript` so the prover and verifier aren't responsible for it. This PR adds such a change.

It also updates `RangeProofTranscript` to hold a mutable reference to the external random number generator. This ensures that the prover and verifier can't accidentally use it instead of the `TranscriptRng`.