### PR TITLE
ci: move to stable toolchain

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Install linter
         run: cargo install cargo-lints
       - name: Lints
-        run: cargo +stable lints clippy --all-targets
+        run: cargo +stable lints clippy --all-targets --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,38 +12,32 @@ jobs:
       - name: toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: stable
           targets: wasm32-unknown-unknown
       - name: build (WASM)
-        run: cargo +nightly-2024-02-01 build --target wasm32-unknown-unknown --no-default-features -Zavoid-dev-deps
+        run: cargo +stable build --target=wasm32-unknown-unknown --no-default-features
 
   test:
     name: cargo test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - nightly-2024-02-01
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - name: toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
-          targets: wasm32-unknown-unknown
+          toolchain: stable
       - name: check (no features)
-        run: cargo +${{ matrix.rust }} check --no-default-features
+        run: cargo +stable check --no-default-features
       - name: check (all features)
-        run: cargo +${{ matrix.rust }} check --all-features --all-targets
+        run: cargo +stable check --all-features --all-targets
       - name: test/debug (all features)
-        run: cargo +${{ matrix.rust }} test --all-features
+        run: cargo +stable test --all-features
       - name: test/debug (no features)
-        run: cargo +${{ matrix.rust }} test --no-default-features
+        run: cargo +stable test --no-default-features
       - name: test/release (all features)
-        run: cargo +${{ matrix.rust }} test --release --all-features
+        run: cargo +stable test --release --all-features
       - name: test/release (no features)
-        run: cargo +${{ matrix.rust }} test --release --no-default-features
+        run: cargo +stable test --release --no-default-features
       - name: Build documentation
-        run: RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.rust }} doc --no-deps
+        run: RUSTDOCFLAGS="-D warnings" cargo +stable doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ digest = { version = "0.10", default-features = false, features = ["alloc"] }
 itertools = { version = "0.12", default-features = false, features = ["use_alloc"] }
 merlin = { version = "3", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["alloc", "critical-section"] }
-rand = { version = "0.8", optional = true, default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 sha3 = { version = "0.10", default-features = false }
@@ -22,15 +21,14 @@ thiserror-no-std = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-bincode = "1"
-criterion = "0.5"
-quickcheck = "1"
-rand_chacha = "0.3.1"
+bincode = { version = "1", default-features = false }
+criterion = { version = "0.5", default-features = false }
+rand_chacha = { version = "0.3.1", default-features = false }
 
 [features]
 default = ["rand", "std"]
-std = ["blake2/std", "byteorder/std", "digest/std", "itertools/use_std", "merlin/std", "once_cell/std", "rand?/std", "rand_core/std", "serde/std", "sha3/std", "zeroize/std"]
-rand = ["dep:rand", "rand/alloc", "rand/getrandom"]
+std = ["blake2/std", "byteorder/std", "digest/std", "itertools/use_std", "merlin/std", "once_cell/std", "rand_core/std", "serde/std", "sha3/std", "zeroize/std"]
+rand = ["rand_core/getrandom"]
 
 [[bench]]
 name = "range_proof"

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -20,9 +20,9 @@ use curve25519_dalek::{
 };
 use itertools::{izip, Itertools};
 use merlin::Transcript;
-#[cfg(feature = "rand")]
-use rand::rngs::OsRng;
 use rand_core::CryptoRngCore;
+#[cfg(feature = "rand")]
+use rand_core::OsRng;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::Zeroizing;
 
@@ -88,7 +88,7 @@ const ENCODED_EXTENSION_SIZE: usize = 1;
 /// use curve25519_dalek::scalar::Scalar;
 /// use merlin::Transcript;
 /// #[cfg(feature = "rand")]
-/// use rand::rngs::OsRng;
+/// use rand_core::OsRng;
 /// # fn main() {
 /// #[cfg(feature = "rand")]
 /// # {
@@ -1270,7 +1270,6 @@ mod tests {
     use core::convert::TryFrom;
 
     use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
-    use quickcheck::QuickCheck;
     use rand_chacha::ChaCha12Rng;
     use rand_core::SeedableRng;
 
@@ -1282,28 +1281,6 @@ mod tests {
         ristretto::{create_pedersen_gens_with_extension_degree, RistrettoRangeProof},
         BulletproofGens,
     };
-
-    #[test]
-    #[allow(clippy::needless_pass_by_value)]
-    fn test_deserialization_fuzzing() {
-        fn internal(bytes: Vec<u8>) -> bool {
-            // Deserialization should either fail or serialize canonically
-            match RistrettoRangeProof::from_bytes(&bytes) {
-                Err(_) => true,
-                Ok(proof) => proof.to_bytes() == bytes,
-            }
-        }
-
-        // Number of fuzzing tests to run
-        const TESTS: u64 = 100_000;
-
-        // Run fuzzing tests
-        QuickCheck::new()
-            .min_tests_passed(TESTS)
-            .tests(TESTS)
-            .max_tests(TESTS)
-            .quickcheck(internal as fn(Vec<u8>) -> bool);
-    }
 
     #[test]
     fn test_from_bytes() {


### PR DESCRIPTION
This PR moves all CI to the stable toolchain, with the single exception of formatting (which requires nightly). It does this by cleaning up the `rand` feature to use `rand_core::OsRng`, which lets the `no_std` build run properly on stable.

Unfortunately, there is no good way to do this while keeping `quickcheck` around. This was only used for very limited fuzz testing; while having any fuzz testing be part of CI is nice, its practical benefit is likely minimal. Further, its functionality is available through the non-CI fuzzer.