### PR TITLE
feat!: remove verifier RNG requirement

### DIFF
--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -172,14 +172,9 @@ fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: Exte
             // Benchmark this code
             b.iter(|| {
                 // 5. Verify the aggregated proof
-                let _masks = RangeProof::verify_batch_with_rng(
-                    &transcript_labels,
-                    &statements,
-                    &proofs,
-                    VerifyAction::VerifyOnly,
-                    &mut rng,
-                )
-                .unwrap();
+                let _masks =
+                    RangeProof::verify_batch(&transcript_labels, &statements, &proofs, VerifyAction::VerifyOnly)
+                        .unwrap();
             });
         });
     }
@@ -259,22 +254,20 @@ fn verify_batched_rangeproofs_helper(bit_length: usize, extension_degree: Extens
                     // Verify the entire batch of proofs
                     match extract_masks {
                         VerifyAction::VerifyOnly => {
-                            let _masks = RangeProof::verify_batch_with_rng(
+                            let _masks = RangeProof::verify_batch(
                                 &transcript_labels,
                                 &statements,
                                 &proofs,
                                 VerifyAction::VerifyOnly,
-                                &mut rng,
                             )
                             .unwrap();
                         },
                         VerifyAction::RecoverOnly => {
-                            let _masks = RangeProof::verify_batch_with_rng(
+                            let _masks = RangeProof::verify_batch(
                                 &transcript_labels,
                                 &statements,
                                 &proofs,
                                 VerifyAction::RecoverOnly,
-                                &mut rng,
                             )
                             .unwrap();
                         },

--- a/src/protocols/transcript_protocol.rs
+++ b/src/protocols/transcript_protocol.rs
@@ -29,6 +29,9 @@ pub trait TranscriptProtocol {
         point: &P,
     ) -> Result<(), ProofError>;
 
+    /// Append a `scalar` with a given `label`.
+    fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
+
     /// Compute a `label`ed challenge variable.
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Result<Scalar, ProofError>;
 }
@@ -55,6 +58,10 @@ impl TranscriptProtocol for Transcript {
             self.append_message(label, point.as_fixed_bytes());
             Ok(())
         }
+    }
+
+    fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {
+        self.append_message(label, scalar.as_bytes());
     }
 
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Result<Scalar, ProofError> {

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -161,6 +161,23 @@ where
         self.transcript.challenge_scalar(b"e")
     }
 
+    /// Update the RNG with the prover's reponses and return it, consuming the transcript
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn to_verifier_rng(mut self, r1: &Scalar, s1: &Scalar, d1: &[Scalar]) -> TranscriptRng {
+        // Update the transcript
+        self.transcript.append_scalar(b"r1", r1);
+        self.transcript.append_scalar(b"s1", s1);
+        for item in d1 {
+            self.transcript.append_scalar(b"d1", item);
+        }
+
+        // Update the RNG
+        self.transcript_rng = Self::build_rng(&self.transcript, self.bytes.as_ref(), self.external_rng);
+
+        // Return the transcript RNG
+        self.transcript_rng
+    }
+
     /// Construct a random number generator from the current transcript state
     ///
     /// Internally, this builds the RNG using a clone of the transcript state, the secret bytes (if provided), and the

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,3 +4,4 @@
 //! Bulletproofs+ utilities
 
 pub mod generic;
+pub(crate) mod nullrng;

--- a/src/utils/nullrng.rs
+++ b/src/utils/nullrng.rs
@@ -1,0 +1,42 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! A null random number generator useful for batch verification.
+
+use rand_core::{
+    impls::{next_u32_via_fill, next_u64_via_fill},
+    CryptoRng,
+    RngCore,
+};
+use zeroize::Zeroize;
+
+/// This is a null random number generator that exists only for deterministic transcript-based weight generation.
+/// It only produces zero.
+/// This is DANGEROUS in general; don't use this for any other purpose!
+pub(crate) struct NullRng;
+
+impl RngCore for NullRng {
+    #[allow(unused_variables)]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        dest.zeroize();
+    }
+
+    #[allow(unused_variables)]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+
+        Ok(())
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        next_u32_via_fill(self)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        next_u64_via_fill(self)
+    }
+}
+
+// This is not actually cryptographically secure!
+// We do this so we can use `NullRng` with `TranscriptRng`.
+impl CryptoRng for NullRng {}

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -247,43 +247,39 @@ fn prove_and_verify(
         if !proofs.is_empty() {
             // 5. Verify the entire batch as the commitment owner, i.e. the prover self
             // --- Only recover the masks
-            let recovered_private_masks = RangeProof::verify_batch_with_rng(
+            let recovered_private_masks = RangeProof::verify_batch(
                 &transcript_labels,
                 &statements_private.clone(),
                 &proofs.clone(),
                 VerifyAction::RecoverOnly,
-                &mut rng,
             )
             .unwrap();
             assert_eq!(private_masks, recovered_private_masks);
             // --- Recover the masks and verify the proofs
-            let recovered_private_masks = RangeProof::verify_batch_with_rng(
+            let recovered_private_masks = RangeProof::verify_batch(
                 &transcript_labels,
                 &statements_private.clone(),
                 &proofs.clone(),
                 VerifyAction::RecoverAndVerify,
-                &mut rng,
             )
             .unwrap();
             assert_eq!(private_masks, recovered_private_masks);
             // --- Verify the proofs but do not recover the masks
-            let recovered_private_masks = RangeProof::verify_batch_with_rng(
+            let recovered_private_masks = RangeProof::verify_batch(
                 &transcript_labels,
                 &statements_private.clone(),
                 &proofs.clone(),
                 VerifyAction::VerifyOnly,
-                &mut rng,
             )
             .unwrap();
             assert_eq!(public_masks, recovered_private_masks);
 
             // 6. Verify the entire batch as public entity
-            let recovered_public_masks = RangeProof::verify_batch_with_rng(
+            let recovered_public_masks = RangeProof::verify_batch(
                 &transcript_labels,
                 &statements_public,
                 &proofs,
                 VerifyAction::VerifyOnly,
-                &mut rng,
             )
             .unwrap();
             assert_eq!(public_masks, recovered_public_masks);
@@ -307,12 +303,11 @@ fn prove_and_verify(
                         seed_nonce: statement.seed_nonce.map(|seed_nonce| seed_nonce + Scalar::ONE),
                     });
                 }
-                let recovered_private_masks_changed = RistrettoRangeProof::verify_batch_with_rng(
+                let recovered_private_masks_changed = RistrettoRangeProof::verify_batch(
                     &transcript_labels,
                     &statements_private_changed,
                     &proofs.clone(),
                     VerifyAction::RecoverAndVerify,
-                    &mut rng,
                 )
                 .unwrap();
                 assert_ne!(private_masks, recovered_private_masks_changed);
@@ -339,12 +334,11 @@ fn prove_and_verify(
                     seed_nonce: statement.seed_nonce,
                 });
             }
-            match RangeProof::verify_batch_with_rng(
+            match RangeProof::verify_batch(
                 &transcript_labels,
                 &statements_public_changed,
                 &proofs,
                 VerifyAction::VerifyOnly,
-                &mut rng,
             ) {
                 Ok(_) => {
                     panic!("Range proof should not verify")


### PR DESCRIPTION
The verifier currently requires support for a random number generator, either provided by the caller or taken from `OsRng`. This is only to produce weights used in the batch verification process; the weights do not need to be cryptographically secure, but must not be known to the prover. This is fine if the verifier has access to a good random number generator, but is not ideal or particularly flexible; in particular, it likely precludes having a WASM verifier.

This PR uses `TranscriptRng` functionality to produce these weights deterministically. It removes the need for the verifier to supply or support any random number generator.

We start by instantiating a new Merlin weight transcript whose only purpose is to bind all proofs together. After processing each proof's `RangeProofTranscript` to produce challenges, we include the prover's responses in the transcript and then use the corresponding `TranscriptRng` to fetch a pseudorandom `u64` that goes into the weight transcript. Once all proofs have been bound in this way, we use the weight transcript's `TranscriptRng` to generate the weights.

Note that because we still use `TranscriptRng` functionality, we need to include a random number generator to satisfy the API. To do this, we build a fake `NullRng` that only outputs zero. This is not safe in general, but is fine in this case.

It's important that we include the prover's responses in each transcript. Normally we don't ever need to do this; however, we don't want the prover to be able to manipulate them in an attempt to bias the weight transcript. If we were doing individual verification or random weighting, this would not be problematic. However, we want to guard against a prover who may be able to influence the batch structure used by the verifier. This is defense in depth and costs effectively nothing.

This is technically a breaking change, since it removes `verify_batch_with_rng` from the public API; the existing `verify_batch` should be used instead, and no longer requires the `rand` feature.

Closes #110.

BREAKING CHANGE: Removes `verify_batch_with_rng` from the public API. No longer requires that `verify_batch` have the `rand` feature enabled.