### PR TITLE
chore: arithmetic lint

### DIFF
--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -38,6 +38,7 @@ static EXTRACT_MASKS: [VerifyAction; 1] = [VerifyAction::VerifyOnly];
 // static EXTENSION_DEGREE: [ExtensionDegree; 3] = [ExtensionDegree::Zero, ExtensionDegree::Two, ExtensionDegree::Four];
 // static EXTRACT_MASKS: [VerifyAction; 2] =  [VerifyAction::VerifyOnly, VerifyAction::RecoverOnly];
 
+#[allow(clippy::arithmetic_side_effects)]
 fn create_aggregated_rangeproof_helper(bit_length: usize, extension_degree: ExtensionDegree, c: &mut Criterion) {
     let mut group = c.benchmark_group("range_proof_creation");
     group.sampling_mode(SamplingMode::Flat);
@@ -111,6 +112,7 @@ fn create_aggregated_rangeproof_n_64(c: &mut Criterion) {
     }
 }
 
+#[allow(clippy::arithmetic_side_effects)]
 fn verify_aggregated_rangeproof_helper(bit_length: usize, extension_degree: ExtensionDegree, c: &mut Criterion) {
     let mut group = c.benchmark_group("range_proof_verification");
     group.sampling_mode(SamplingMode::Flat);
@@ -193,6 +195,7 @@ fn verify_aggregated_rangeproof_n_64(c: &mut Criterion) {
     }
 }
 
+#[allow(clippy::arithmetic_side_effects)]
 fn verify_batched_rangeproofs_helper(bit_length: usize, extension_degree: ExtensionDegree, c: &mut Criterion) {
     let mut group = c.benchmark_group("batched_range_proof_verification");
     group.sampling_mode(SamplingMode::Flat);

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+arithmetic-side-effects-allowed = [ "tari_curve25519_dalek::Scalar" ]

--- a/lints.toml
+++ b/lints.toml
@@ -43,5 +43,8 @@ deny = [
     'clippy::cast_possible_truncation',
     'clippy::cast_possible_wrap',
     'clippy::cast_precision_loss',
-    'clippy::cast_sign_loss'
+    'clippy::cast_sign_loss',
+    
+    # Mathematical mistakes
+    'clippy::arithmetic_side_effects',
 ]

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -83,6 +83,7 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
 }
 
 /// A static array of pre-generated points
+#[allow(clippy::arithmetic_side_effects)]
 fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::COUNT] {
     static INSTANCE: OnceCell<[RistrettoPoint; ExtensionDegree::COUNT]> = OnceCell::new();
     INSTANCE.get_or_init(|| {

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -90,6 +90,7 @@ where
 
         // Serialize the witness if provided
         let bytes = if let Some(witness) = witness {
+            #[allow(clippy::arithmetic_side_effects)]
             let size: usize = witness
                 .openings
                 .iter()

--- a/tests/ristretto.rs
+++ b/tests/ristretto.rs
@@ -147,6 +147,7 @@ enum ProofOfMinimumValueStrategy {
     LargerThanValue,
 }
 
+#[allow(clippy::arithmetic_side_effects)]
 fn prove_and_verify(
     bit_lengths: &[usize],
     proof_batch: &[usize],


### PR DESCRIPTION
The [Quarkslab audit](https://github.com/tari-project/bulletproofs-plus/blob/da71f7872f02a0e9d3000c316bb083181daa9942/docs/quarkslab-audit/README.md) of this library recommended the use of an arithmetic side-effect lint. This was not done at the time due to difficulty getting the lint to work with Ristretto types, which do not pose risk.

This PR adds the lint and makes necessary changes to account for it.

Closes #117.