### PR TITLE
fix: pin nightly version on source cov workflow

### DIFF
--- a/.github/workflows/source-cov.yml
+++ b/.github/workflows/source-cov.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  RUSTUP_TOOLCHAIN: "nightly"
+  RUSTUP_TOOLCHAIN: "stable"
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -18,7 +18,7 @@ jobs:
       - name: Download Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: {{ env.RUSTUP_TOOLCHAIN }}
           components: llvm-tools-preview
       - name: Install requirements for code coverage
         run: |


### PR DESCRIPTION
A bandaid over the issue of source coverage failing due to Dalek being a naughty library again.

Clearly a temporary fix, since this will break again some thim in the future.