### PR TITLE
fix: reduce verification vector allocation

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -778,7 +778,7 @@ where
         let mut msm_dynamic_len = extension_degree.checked_add(1).ok_or(ProofError::SizeOverflow)?;
         for (statement, proof) in statements.iter().zip(range_proofs.iter()) {
             msm_dynamic_len = msm_dynamic_len
-                .checked_add(statement.generators.aggregation_factor())
+                .checked_add(statement.commitments.len())
                 .ok_or(ProofError::SizeOverflow)?;
             msm_dynamic_len = msm_dynamic_len.checked_add(3).ok_or(ProofError::SizeOverflow)?;
             msm_dynamic_len = msm_dynamic_len


### PR DESCRIPTION
Batch verification vectors are allocated in part using the expected aggregation factor of each statement in the batch. However, this was being done using the aggregation factors corresponding to each statement's associated generators, which may exceed the aggregation factors actually used in the statements. The result was a possible over-allocation of these vectors.

This PR changes the allocation to use the actual aggregation factors.

Closes #126.