### PR TITLE
feat: remove partial precomputation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ blake2 = { version = "0.10", default-features = false }
 byteorder = { version = "1", default-features = false }
 curve25519-dalek = { version = "4.1", default-features = false, features = ["alloc", "group", "rand_core", "serde", "zeroize"] }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
+ff = { version = "0.13.0", default-features = false }
 itertools = { version = "0.12", default-features = false, features = ["use_alloc"] }
 merlin = { version = "3", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["alloc", "critical-section"] }
@@ -27,7 +28,7 @@ rand_chacha = { version = "0.3.1", default-features = false }
 
 [features]
 default = ["rand", "std"]
-std = ["blake2/std", "byteorder/std", "digest/std", "itertools/use_std", "merlin/std", "once_cell/std", "rand_core/std", "serde/std", "sha3/std", "zeroize/std"]
+std = ["blake2/std", "byteorder/std", "digest/std", "ff/std", "itertools/use_std", "merlin/std", "once_cell/std", "rand_core/std", "serde/std", "sha3/std", "zeroize/std"]
 rand = ["rand_core/getrandom"]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { package = "tari-curve25519-dalek", version = "4.0.3", default-features = false, features = ["alloc", "rand_core", "serde", "zeroize"] }
+curve25519-dalek = { version = "4.1", default-features = false, features = ["alloc", "group", "rand_core", "serde", "zeroize"] }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
 itertools = { version = "0.12", default-features = false, features = ["use_alloc"] }
 merlin = { version = "3", default-features = false }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-arithmetic-side-effects-allowed = [ "tari_curve25519_dalek::Scalar" ]
+arithmetic-side-effects-allowed = [ "curve25519_dalek::Scalar" ]

--- a/docs/quarkslab-audit/README.md
+++ b/docs/quarkslab-audit/README.md
@@ -41,6 +41,9 @@ Developers are in the process of testing an updated version of the fork, in orde
 
 Further, an open [upstream pull request](https://github.com/dalek-cryptography/curve25519-dalek/pull/546) would add partial precomputation support; if it is accepted, the implementation could change its curve library dependency to upstream.
 
+*Update*: The library has removed support for partial precomputation in favor of a different design.
+As a result, the curve library dependency has been changed to upstream.
+
 ## `INFO 2`
 
 This issue ran the `clippy` linter against several lints, and identified a number of warnings arising from them.

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -37,7 +37,7 @@ use crate::{
     traits::{Compressable, Decompressable, FixedBytesRepr, Precomputable},
     transcripts::RangeProofTranscript,
     utils::{
-        generic::{nonce, split_at_checked},
+        generic::{compute_generator_padding, nonce, split_at_checked},
         nullrng::NullRng,
     },
 };
@@ -331,15 +331,11 @@ where
                 Scalar::random_not_zero(range_proof_transcript.as_mut_rng())
             });
         }
-        let padding = 2usize
-            .checked_mul(statement.generators.bit_length())
-            .ok_or(ProofError::SizeOverflow)?
-            .checked_mul(statement.generators.aggregation_factor())
-            .ok_or(ProofError::SizeOverflow)?
-            .checked_sub(a_li.len())
-            .ok_or(ProofError::SizeOverflow)?
-            .checked_sub(a_ri.len())
-            .ok_or(ProofError::SizeOverflow)?;
+        let padding = compute_generator_padding(
+            statement.generators.bit_length(),
+            statement.commitments.len(),
+            statement.generators.aggregation_factor(),
+        )?;
         let a = statement.generators.precomp().vartime_mixed_multiscalar_mul(
             a_li.iter()
                 .interleave(a_ri.iter())
@@ -1035,15 +1031,11 @@ where
         dynamic_points.push(h_base.clone());
 
         // Perform the final check using precomputation
-        let padding = 2usize
-            .checked_mul(max_statement.generators.bit_length())
-            .ok_or(ProofError::SizeOverflow)?
-            .checked_mul(max_statement.generators.aggregation_factor())
-            .ok_or(ProofError::SizeOverflow)?
-            .checked_sub(max_mn)
-            .ok_or(ProofError::SizeOverflow)?
-            .checked_sub(max_mn)
-            .ok_or(ProofError::SizeOverflow)?;
+        let padding = compute_generator_padding(
+            max_statement.generators.bit_length(),
+            max_statement.commitments.len(),
+            max_statement.generators.aggregation_factor(),
+        )?;
         if precomp.vartime_mixed_multiscalar_mul(
             gi_base_scalars
                 .iter()

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -18,6 +18,7 @@ use curve25519_dalek::{
     scalar::Scalar,
     traits::{Identity, IsIdentity, MultiscalarMul, VartimePrecomputedMultiscalarMul},
 };
+use ff::Field;
 use itertools::{izip, Itertools};
 use merlin::Transcript;
 use rand_core::CryptoRngCore;
@@ -774,7 +775,7 @@ where
 
         // Compute 2**n-1 for later use
         let two = Scalar::from(2u8);
-        let two_n_minus_one = (0..bit_length.ilog2()).fold(two, |acc, _| acc * acc) - Scalar::ONE;
+        let two_n_minus_one = two.pow_vartime([bit_length as u64]) - Scalar::ONE;
 
         // Weighted coefficients for common generators
         let mut g_base_scalars = vec![Scalar::ZERO; extension_degree];
@@ -901,7 +902,7 @@ where
             let e_square = e * e;
             let challenges_sq: Vec<Scalar> = challenges.iter().map(|c| c * c).collect();
             let challenges_sq_inv: Vec<Scalar> = challenges_inv.iter().map(|c| c * c).collect();
-            let y_nm = (0..rounds).fold(y, |y_nm, _| y_nm * y_nm);
+            let y_nm = y.pow_vartime([full_length as u64]);
             let y_nm_1 = y_nm * y;
 
             // Compute the sum of powers of the challenge as a partial sum of a geometric series


### PR DESCRIPTION
Partial precomputation is the sole reason for maintaining a custom curve library fork, which has proven to be a headache and limits compatibility with other libraries.

This PR removes partial precomputation altogether. If you supply parameters with more inner-product generators than you need, padding is used. This incurs an efficiency hit, but only in this particular case. For the use cases in the Tari ecosystem, this is not an issue.

As a result of this change, we also switch back to the latest version of the upstream curve library and simplify some scalar exponentiation operations. The audit report is also updated to note the curve library dependency change.

Closes #128. Closes #93. Closes #96.