### PR TITLE
chore: remove custom vector splitting

### DIFF
--- a/src/generators/pedersen_gens.rs
+++ b/src/generators/pedersen_gens.rs
@@ -21,7 +21,6 @@ use crate::{errors::ProofError, traits::Compressable};
 ///
 /// * `h_base`: the curve basepoint;
 /// * `g_base_vec`: the result of domain separated SHA3-512 (hash of unique indexed strings)
-/// hash-to-group on input `B_bytes`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PedersenGens<P: Compressable> {
     /// Base for the committed value

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -37,7 +37,7 @@ use crate::{
     traits::{Compressable, Decompressable, FixedBytesRepr, Precomputable},
     transcripts::RangeProofTranscript,
     utils::{
-        generic::{compute_generator_padding, nonce, split_at_checked},
+        generic::{compute_generator_padding, nonce},
         nullrng::NullRng,
     },
 };
@@ -410,10 +410,18 @@ where
             n /= 2;
 
             // Split the vectors for folding
-            let (a_lo, a_hi) = split_at_checked(&a_li, n)?;
-            let (b_lo, b_hi) = split_at_checked(&a_ri, n)?;
-            let (gi_base_lo, gi_base_hi) = split_at_checked(&gi_base, n)?;
-            let (hi_base_lo, hi_base_hi) = split_at_checked(&hi_base, n)?;
+            let (a_lo, a_hi) = a_li
+                .split_at_checked(n)
+                .ok_or(ProofError::InvalidLength("Invalid vector split index".to_string()))?;
+            let (b_lo, b_hi) = a_ri
+                .split_at_checked(n)
+                .ok_or(ProofError::InvalidLength("Invalid vector split index".to_string()))?;
+            let (gi_base_lo, gi_base_hi) = gi_base
+                .split_at_checked(n)
+                .ok_or(ProofError::InvalidLength("Invalid vector split index".to_string()))?;
+            let (hi_base_lo, hi_base_hi) = hi_base
+                .split_at_checked(n)
+                .ok_or(ProofError::InvalidLength("Invalid vector split index".to_string()))?;
 
             let y_n_inverse = if y_powers[n] == Scalar::ZERO {
                 return Err(ProofError::InvalidArgument(

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -59,15 +59,6 @@ pub fn nonce(
     Ok(Scalar::from_hasher_blake2b(hasher))
 }
 
-/// Split a vector, checking the bound to avoid a panic
-pub fn split_at_checked<T>(vec: &[T], n: usize) -> Result<(&[T], &[T]), ProofError> {
-    if n <= vec.len() {
-        Ok(vec.split_at(n))
-    } else {
-        Err(ProofError::InvalidLength("Invalid vector split index".to_string()))
-    }
-}
-
 /// Compute the padding needed for generator vectors
 pub fn compute_generator_padding(
     bit_length: usize,
@@ -92,7 +83,7 @@ pub fn compute_generator_padding(
 
 #[cfg(test)]
 mod tests {
-    use alloc::{vec, vec::Vec};
+    use alloc::vec;
 
     use curve25519_dalek::scalar::Scalar;
     use rand_chacha::ChaCha12Rng;
@@ -111,36 +102,6 @@ mod tests {
         // Invalid
         assert!(compute_generator_padding(64, 2, 1).is_err());
         assert!(compute_generator_padding(64, usize::MAX - 1, usize::MAX).is_err());
-    }
-
-    #[test]
-    fn test_split() {
-        // Check valid splits
-        let v = vec![0u8, 1u8, 2u8];
-        let (l, r) = split_at_checked(&v, 0).unwrap();
-        assert_eq!(l, Vec::<u8>::new());
-        assert_eq!(r, vec![0u8, 1u8, 2u8]);
-
-        let (l, r) = split_at_checked(&v, 1).unwrap();
-        assert_eq!(l, vec![0u8]);
-        assert_eq!(r, vec![1u8, 2u8]);
-
-        let (l, r) = split_at_checked(&v, 2).unwrap();
-        assert_eq!(l, vec![0u8, 1u8]);
-        assert_eq!(r, vec![2u8]);
-
-        let (l, r) = split_at_checked(&v, 3).unwrap();
-        assert_eq!(l, vec![0u8, 1u8, 2u8]);
-        assert_eq!(r, Vec::<u8>::new());
-
-        // Check invalid split
-        assert!(split_at_checked(&v, 4).is_err());
-
-        // Split an empty vector
-        let v = Vec::<u8>::new();
-        let (l, r) = split_at_checked(&v, 0).unwrap();
-        assert_eq!(l, Vec::<u8>::new());
-        assert_eq!(r, Vec::<u8>::new());
     }
 
     #[test]


### PR DESCRIPTION
This PR removes a custom vector splitting function with [new functionality](https://doc.rust-lang.org/std/primitive.slice.html#method.split_at_checked) from the standard library. It also removes an old unused comment line that made the formatter angry.