### PR TITLE
chore: remove use of default for points and scalars

### DIFF
--- a/src/protocols/transcript_protocol.rs
+++ b/src/protocols/transcript_protocol.rs
@@ -80,7 +80,7 @@ impl TranscriptProtocol for Transcript {
 
 #[cfg(test)]
 mod test {
-    use curve25519_dalek::RistrettoPoint;
+    use curve25519_dalek::{traits::Identity, RistrettoPoint};
     use merlin::Transcript;
 
     use super::*;
@@ -89,7 +89,7 @@ mod test {
     fn test_identity_point() {
         let mut transcript = Transcript::new(b"test");
         assert!(transcript
-            .validate_and_append_point(b"identity", &RistrettoPoint::default().compress())
+            .validate_and_append_point(b"identity", &RistrettoPoint::identity().compress())
             .is_err());
     }
 }

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -1337,11 +1337,11 @@ mod tests {
         assert!((RistrettoRangeProof::from_bytes(&[])).is_err());
         assert!((RistrettoRangeProof::from_bytes(Scalar::ZERO.as_bytes().as_slice())).is_err());
         let proof = RistrettoRangeProof {
-            a: Default::default(),
-            a1: Default::default(),
-            b: Default::default(),
-            r1: Default::default(),
-            s1: Default::default(),
+            a: CompressedRistretto::identity(),
+            a1: CompressedRistretto::identity(),
+            b: CompressedRistretto::identity(),
+            r1: Scalar::ZERO,
+            s1: Scalar::ZERO,
             d1: vec![],
             li: vec![],
             ri: vec![],
@@ -1351,14 +1351,14 @@ mod tests {
         assert!(RistrettoRangeProof::from_bytes(&proof_bytes).is_err());
 
         let proof = RistrettoRangeProof {
-            a: Default::default(),
-            a1: Default::default(),
-            b: Default::default(),
-            r1: Default::default(),
-            s1: Default::default(),
-            d1: vec![Scalar::default()],
-            li: vec![CompressedRistretto::default()],
-            ri: vec![CompressedRistretto::default()],
+            a: CompressedRistretto::identity(),
+            a1: CompressedRistretto::identity(),
+            b: CompressedRistretto::identity(),
+            r1: Scalar::ZERO,
+            s1: Scalar::ZERO,
+            d1: vec![Scalar::ZERO],
+            li: vec![CompressedRistretto::identity()],
+            ri: vec![CompressedRistretto::identity()],
             extension_degree: ExtensionDegree::DefaultPedersen,
         };
         let proof_bytes = proof.to_bytes();
@@ -1370,21 +1370,21 @@ mod tests {
         );
 
         let proof = RistrettoRangeProof {
-            a: Default::default(),
-            a1: Default::default(),
-            b: Default::default(),
-            r1: Default::default(),
-            s1: Default::default(),
+            a: CompressedRistretto::identity(),
+            a1: CompressedRistretto::identity(),
+            b: CompressedRistretto::identity(),
+            r1: Scalar::ZERO,
+            s1: Scalar::ZERO,
             d1: vec![
-                Scalar::default(),
-                Scalar::default(),
-                Scalar::default(),
-                Scalar::default(),
-                Scalar::default(),
-                Scalar::default(),
+                Scalar::ZERO,
+                Scalar::ZERO,
+                Scalar::ZERO,
+                Scalar::ZERO,
+                Scalar::ZERO,
+                Scalar::ZERO,
             ],
-            li: vec![CompressedRistretto::default()],
-            ri: vec![CompressedRistretto::default()],
+            li: vec![CompressedRistretto::identity()],
+            ri: vec![CompressedRistretto::identity()],
             extension_degree: ExtensionDegree::AddFiveBasePoints,
         };
         let proof_bytes = proof.to_bytes();
@@ -1492,7 +1492,7 @@ mod tests {
 
         // Make the second statement's `g_base_vec` mismatch against the first statement
         let mut gens_mismatch = create_pedersen_gens_with_extension_degree(ExtensionDegree::DefaultPedersen);
-        gens_mismatch.g_base_vec[0] = RistrettoPoint::default();
+        gens_mismatch.g_base_vec[0] = RistrettoPoint::identity();
         let params_mismatch = RangeParameters::init(4, 1, gens_mismatch).unwrap();
         let statement_mismatch = RangeStatement::init(
             params_mismatch.clone(),
@@ -1509,7 +1509,7 @@ mod tests {
 
         // Make the second statement's `h_base` mismatch against the first statement
         let mut gens_mismatch = create_pedersen_gens_with_extension_degree(ExtensionDegree::DefaultPedersen);
-        gens_mismatch.h_base = RistrettoPoint::default();
+        gens_mismatch.h_base = RistrettoPoint::identity();
         let params_mismatch = RangeParameters::init(4, 1, gens_mismatch).unwrap();
         let statement_mismatch = RangeStatement::init(
             params_mismatch.clone(),
@@ -1577,7 +1577,7 @@ mod tests {
 
         // Make the second statement's `gi_base` mismatch against the first statement
         let mut gens_mismatch = BulletproofGens::new(4, 1).unwrap();
-        gens_mismatch.g_vec[0][0] = RistrettoPoint::default();
+        gens_mismatch.g_vec[0][0] = RistrettoPoint::identity();
         let params_mismatch = RangeParameters {
             bp_gens: gens_mismatch,
             pc_gens: create_pedersen_gens_with_extension_degree(ExtensionDegree::DefaultPedersen),
@@ -1597,7 +1597,7 @@ mod tests {
 
         // Make the second statement's `hi_base` mismatch against the first statement
         let mut gens_mismatch = BulletproofGens::new(4, 1).unwrap();
-        gens_mismatch.h_vec[0][0] = RistrettoPoint::default();
+        gens_mismatch.h_vec[0][0] = RistrettoPoint::identity();
         let params_mismatch = RangeParameters {
             bp_gens: gens_mismatch,
             pc_gens: create_pedersen_gens_with_extension_degree(ExtensionDegree::DefaultPedersen),

--- a/src/range_statement.rs
+++ b/src/range_statement.rs
@@ -84,7 +84,7 @@ impl<P: Compressable + Precomputable> Drop for RangeStatement<P> {
 mod test {
     use alloc::vec;
 
-    use curve25519_dalek::RistrettoPoint;
+    use curve25519_dalek::{traits::Identity, RistrettoPoint};
 
     use super::*;
     use crate::{
@@ -95,7 +95,7 @@ mod test {
 
     #[test]
     fn test_init_errors() {
-        let p = RistrettoPoint::default();
+        let p = RistrettoPoint::identity();
 
         // Set up parameters
         let params = RangeParameters::init(

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -10,6 +10,7 @@ use alloc::{borrow::ToOwned, string::ToString, vec::Vec};
 use curve25519_dalek::{
     constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
     ristretto::{CompressedRistretto, RistrettoPoint, VartimeRistrettoPrecomputation},
+    traits::Identity,
 };
 use once_cell::sync::OnceCell;
 
@@ -87,7 +88,7 @@ fn get_g_base(extension_degree: ExtensionDegree) -> (Vec<RistrettoPoint>, Vec<Co
 fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::COUNT] {
     static INSTANCE: OnceCell<[RistrettoPoint; ExtensionDegree::COUNT]> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let mut arr = [RistrettoPoint::default(); ExtensionDegree::COUNT];
+        let mut arr = [RistrettoPoint::identity(); ExtensionDegree::COUNT];
         for (i, point) in (ExtensionDegree::MINIMUM..).zip(arr.iter_mut()) {
             let label = "RISTRETTO_MASKING_BASEPOINT_".to_owned() + &i.to_string();
             *point = RistrettoPoint::hash_from_bytes_sha3_512(label.as_bytes());
@@ -101,7 +102,7 @@ fn ristretto_masking_basepoints() -> &'static [RistrettoPoint; ExtensionDegree::
 fn ristretto_compressed_masking_basepoints() -> &'static [CompressedRistretto; ExtensionDegree::COUNT] {
     static INSTANCE: OnceCell<[CompressedRistretto; ExtensionDegree::COUNT]> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let mut arr = [CompressedRistretto::default(); ExtensionDegree::COUNT];
+        let mut arr = [CompressedRistretto::identity(); ExtensionDegree::COUNT];
         for (i, point) in ristretto_masking_basepoints().iter().enumerate() {
             arr[i] = point.compress();
         }


### PR DESCRIPTION
The use of the `Default` implementation for Ristretto point and scalar types is somewhat non-idiomatic, since it isn't immediately clear what a "default" point or scalar must be. In practice, these are the identity group element and zero scalar, respectively.

This PR removes ambiguity and makes the library more future proof by removing all such uses. Instead, it uses the `Identity` implementation for point types and the `ZERO` constant for scalars.

Closes #141.