### PR TITLE
fix: pin curve25519-dalek to 5.0.0-pre.6 (#148)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_bulletproofs_plus"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Tari Development Community"]
 edition = "2024"
 license = "BSD-3-Clause"
@@ -9,7 +9,10 @@ description = "A smaller faster implementation of Bulletproofs"
 [dependencies]
 blake2 = { version = "0.10", default-features = false }
 byteorder = { version = "1", default-features = false }
-curve25519-dalek = { version = "5.0.0-pre.6", default-features = false, features = ["alloc", "group", "rand_core", "serde", "zeroize"] }
+# Pinned exactly: the default caret requirement `5.0.0-pre.6` also permits the newer pre-release
+# `5.0.0-rc.1`, which switches its `ff`/`group` backend from `rustcrypto-ff`/`rustcrypto-group` to the
+# upstream `ff`/`group` crates and breaks the build (see issue #148). Pin until we migrate to the RC.
+curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, features = ["alloc", "group", "rand_core", "serde", "zeroize"] }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
 ff = { package = "rustcrypto-ff", version = "0.14.0-rc", default-features = false }
 getrandom = { version = "0.4", default-features = false, features = ["sys_rng"], optional = true }


### PR DESCRIPTION
## Summary

Fixes #148 — 0.5.0 fails to compile when the resolver selects `curve25519-dalek` **`5.0.0-rc.1`** instead of `5.0.0-pre.6`.

The default caret requirement `version = "5.0.0-pre.6"` also permits the newer pre-release `5.0.0-rc.1` (`rc.1 > pre.6` in SemVer pre-release ordering). `curve25519-dalek 5.0.0-rc.1` switched its `group`/`ff` backend from `rustcrypto-ff`/`rustcrypto-group` to the upstream `ff`/`group` `0.14` crates, so its `Scalar` no longer implements `rustcrypto-ff::Field`. Since `range_proof.rs` only imports `rustcrypto-ff::Field`, `Scalar::pow_vartime` falls out of scope and the build fails with `E0599` (at `range_proof.rs:783` and `:912`).

## Change

- Pin the requirement exactly to `curve25519-dalek = "=5.0.0-pre.6"` so the incompatible RC can no longer be selected by the resolver. Downstream crates that let `curve25519-dalek` float now inherit this constraint (per the "tighten the requirement" suggestion in the issue).
- Bump the package version to `0.5.1`.

This is the minimal, low-risk fix. Migrating to `5.0.0-rc.1` + upstream `ff`/`group` `0.14` is left as separate follow-up work.

## Verification

- `cargo build` and `cargo test --lib` pass (26 tests) with `curve25519-dalek 5.0.0-pre.6`.
- `cargo update -p curve25519-dalek --precise 5.0.0-rc.1` is now **rejected** by the resolver:
  ```
  error: failed to select a version for the requirement `curve25519-dalek = "=5.0.0-pre.6"`
  candidate versions found which didn't match: 5.0.0-rc.1
  ```

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)